### PR TITLE
15 amendment 반영 서비스 개발

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,6 @@ dependencies {
     //mokito
     testImplementation 'org.mockito:mockito-core'
 
-
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,10 @@ dependencies {
     //api document automation
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 
+    //mokito
+    testImplementation 'org.mockito:mockito-core'
+
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/src/main/java/goorm/eagle7/stelligence/common/merge/MergeService.java
+++ b/src/main/java/goorm/eagle7/stelligence/common/merge/MergeService.java
@@ -1,0 +1,53 @@
+package goorm.eagle7.stelligence.common.merge;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import goorm.eagle7.stelligence.common.merge.handler.AmendmentMergeTemplateMapper;
+import goorm.eagle7.stelligence.domain.amendment.model.Amendment;
+import goorm.eagle7.stelligence.domain.contribute.model.Contribute;
+import goorm.eagle7.stelligence.domain.document.DocumentRepository;
+import goorm.eagle7.stelligence.domain.document.model.Document;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * MergeService
+ * 투표가 종료된 Amendment들을 원본에 반영하기 위한 서비스 클래스입니다.
+ * 배치 작업으로부터 호출되어야 합니다.
+ */
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MergeService {
+
+	private final DocumentRepository documentRepository;
+	private final AmendmentMergeTemplateMapper amendmentMergeTemplateMapper;
+
+	/**
+	 * Contribute의 Amendment들을 원본에 반영합니다.
+	 * @param documentId 반영될 Document ID
+	 * @param contribute 반영할 Contribute
+	 */
+	public void merge(Long documentId, Contribute contribute) {
+
+		Document document = documentRepository.findForUpdate(documentId)
+			.orElseThrow(() -> new RuntimeException("Document가 존재하지 않습니다."));
+
+		List<Amendment> amendments = contribute.getAmendments();
+
+		/*
+		 * 각각의 amendment에 대하여
+		 * Merge 로직을 가지고 있는 handler를 찾아서 실행합니다.
+		 */
+		amendments.forEach(amendment ->
+			amendmentMergeTemplateMapper.getTemplateForType(amendment.getType())
+				.handle(document, amendment)
+		);
+
+		document.incrementCurrentRevision();
+	}
+}

--- a/src/main/java/goorm/eagle7/stelligence/common/merge/handler/AmendmentMergeTemplate.java
+++ b/src/main/java/goorm/eagle7/stelligence/common/merge/handler/AmendmentMergeTemplate.java
@@ -1,0 +1,53 @@
+package goorm.eagle7.stelligence.common.merge.handler;
+
+import org.springframework.stereotype.Component;
+
+import goorm.eagle7.stelligence.domain.amendment.model.Amendment;
+import goorm.eagle7.stelligence.domain.document.model.Document;
+import goorm.eagle7.stelligence.domain.section.SectionRepository;
+import goorm.eagle7.stelligence.domain.section.model.Section;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * AmendmentMergeTemplate
+ * 서로 다른 타입에 대하여 다르게 동작하는 병합과정을 분리해내고 공통적인 부분을 추출해낸 추상클래스입니다.
+ * Template Method Pattern을 사용하여, 각 타입에 맞는 섹션의 생성은 createSection에서 수행하고
+ * sectionRepository.save 메서드나 member.contributes 증가시키는 로직과 같이
+ * 공통적으로 수행되어야 하는 코드는 이곳에서 수행됩니다.
+ */
+@Component
+@RequiredArgsConstructor
+public abstract class AmendmentMergeTemplate {
+
+	private final SectionRepository sectionRepository;
+
+	/**
+	 * Amendment Type에 따라 서로 다른 방식의 Section을 생성합니다.
+	 * 이렇게 생성된 Section은 SectionRepository를 통해 저장됩니다.
+	 * @param document
+	 * @param amendment
+	 * @return
+	 */
+	abstract Section createSection(Document document, Amendment amendment);
+
+	/**
+	 * Amendment Type에 따라 서로 다른 방식의 추가 작업을 수행합니다.
+	 * @param section
+	 */
+	abstract void afterMerged(Section section);
+
+	public final void handle(Document document, Amendment amendment) {
+		//템플릿에 따라 Section을 생성한다.
+		Section section = createSection(document, amendment);
+
+		//템플릿에 상관없이 공통적으로 섹션을 저장한다.
+		sectionRepository.save(section);
+
+		/**
+		 * TODO : 이 부분에서 Member의 Contribute를 올려주는 코드 작성
+		 */
+
+		//템플릿에 따라 추가적인 작업을 수행한다.
+		afterMerged(section);
+	}
+}

--- a/src/main/java/goorm/eagle7/stelligence/common/merge/handler/AmendmentMergeTemplateMapper.java
+++ b/src/main/java/goorm/eagle7/stelligence/common/merge/handler/AmendmentMergeTemplateMapper.java
@@ -1,0 +1,28 @@
+package goorm.eagle7.stelligence.common.merge.handler;
+
+import org.springframework.stereotype.Component;
+
+import goorm.eagle7.stelligence.domain.amendment.model.AmendmentType;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * AmendmentMergeTemplateMapper
+ *
+ * Amendment 타입에 따라 적합한 AmendmentMergeTemplate을 반환합니다.
+ */
+@Component
+@RequiredArgsConstructor
+public class AmendmentMergeTemplateMapper {
+
+	private final CreateAmendmentMergeTemplate createAmendmentMergeTemplate;
+	private final UpdateAmendmentMergeTemplate updateAmendmentMergeTemplate;
+	private final DeleteAmendmentMergeTemplate deleteAmendmentMergeTemplate;
+
+	public AmendmentMergeTemplate getTemplateForType(AmendmentType type) {
+		return switch (type) {
+			case CREATE -> createAmendmentMergeTemplate;
+			case UPDATE -> updateAmendmentMergeTemplate;
+			case DELETE -> deleteAmendmentMergeTemplate;
+		};
+	}
+}

--- a/src/main/java/goorm/eagle7/stelligence/common/merge/handler/CreateAmendmentMergeTemplate.java
+++ b/src/main/java/goorm/eagle7/stelligence/common/merge/handler/CreateAmendmentMergeTemplate.java
@@ -1,0 +1,62 @@
+package goorm.eagle7.stelligence.common.merge.handler;
+
+import org.springframework.stereotype.Component;
+
+import goorm.eagle7.stelligence.common.sequence.SectionIdGenerator;
+import goorm.eagle7.stelligence.domain.amendment.model.Amendment;
+import goorm.eagle7.stelligence.domain.document.model.Document;
+import goorm.eagle7.stelligence.domain.section.SectionRepository;
+import goorm.eagle7.stelligence.domain.section.model.Section;
+
+/**
+ * CreateAmendmentMergeTemplate
+ * 생성 타입의 수정안에 대해 병합을 수행합니다.
+ */
+@Component
+public class CreateAmendmentMergeTemplate extends AmendmentMergeTemplate {
+
+	/**
+	 * 새로운 ID를 가진 섹션의 생성을 위해 SectionIdGenerator를 주입받습니다.
+	 */
+	private final SectionIdGenerator sectionIdGenerator;
+	private final SectionRepository sectionRepository;
+
+	public CreateAmendmentMergeTemplate(
+		SectionRepository sectionRepository,
+		SectionIdGenerator sectionIdGenerator
+	) {
+		super(sectionRepository);
+		this.sectionIdGenerator = sectionIdGenerator;
+		this.sectionRepository = sectionRepository;
+	}
+
+	/**
+	 * 수정안의 정보를 바탕으로 새로운 섹션을 생성합니다.
+	 * @param document
+	 * @param amendment
+	 * @return
+	 */
+	@Override
+	Section createSection(Document document, Amendment amendment) {
+		return Section.createSection(
+			document,
+			sectionIdGenerator.getAndIncrementSectionId(), //새로운 섹션의 삽입이므로 ID를 새로 생성합니다.
+			document.getCurrentRevision() + 1,
+			amendment.getNewSectionHeading(),
+			amendment.getNewSectionTitle(),
+			amendment.getNewSectionContent(),
+			amendment.getTargetSection().getOrder() + 1 //섹션은 targetSection의 다음 위치에 삽입됩니다.
+		);
+	}
+
+	/**
+	 * 새로운 섹션의 생성에 따라 섹션의 순서를 업데이트합니다.
+	 * @param section
+	 */
+	@Override
+	void afterMerged(Section section) {
+		Document document = section.getDocument();
+		sectionRepository.updateOrders(document.getId(), document.getCurrentRevision(), section.getOrder());
+	}
+
+}

--- a/src/main/java/goorm/eagle7/stelligence/common/merge/handler/DeleteAmendmentMergeTemplate.java
+++ b/src/main/java/goorm/eagle7/stelligence/common/merge/handler/DeleteAmendmentMergeTemplate.java
@@ -1,0 +1,48 @@
+package goorm.eagle7.stelligence.common.merge.handler;
+
+import org.springframework.stereotype.Component;
+
+import goorm.eagle7.stelligence.domain.amendment.model.Amendment;
+import goorm.eagle7.stelligence.domain.document.model.Document;
+import goorm.eagle7.stelligence.domain.section.SectionRepository;
+import goorm.eagle7.stelligence.domain.section.model.Section;
+
+/**
+ * DeleteAmendmentMergeTemplate
+ * 삭제 타입의 수정안에 대해 병합을 수행합니다.
+ */
+@Component
+public class DeleteAmendmentMergeTemplate extends AmendmentMergeTemplate {
+
+	public DeleteAmendmentMergeTemplate(SectionRepository sectionRepository) {
+		super(sectionRepository);
+	}
+
+	/**
+	 * 수정안의 정보를 바탕으로 새로운 섹션을 생성합니다.
+	 *
+	 * 삭제 타입의 경우, 기존 섹션의 ID를 그대로 사용합니다.
+	 * 섹션의 content가 null인 경우 삭제로 인식합니다.
+	 *
+	 * @param document
+	 * @param amendment
+	 * @return
+	 */
+	@Override
+	Section createSection(Document document, Amendment amendment) {
+		return Section.createSection(
+			document,
+			amendment.getTargetSection().getId(),
+			document.getCurrentRevision() + 1,
+			null,
+			null,
+			null,
+			amendment.getTargetSection().getOrder()
+		);
+	}
+
+	@Override
+	void afterMerged(Section section) {
+		//do nothing
+	}
+}

--- a/src/main/java/goorm/eagle7/stelligence/common/merge/handler/UpdateAmendmentMergeTemplate.java
+++ b/src/main/java/goorm/eagle7/stelligence/common/merge/handler/UpdateAmendmentMergeTemplate.java
@@ -1,0 +1,49 @@
+package goorm.eagle7.stelligence.common.merge.handler;
+
+import org.springframework.stereotype.Component;
+
+import goorm.eagle7.stelligence.domain.amendment.model.Amendment;
+import goorm.eagle7.stelligence.domain.document.model.Document;
+import goorm.eagle7.stelligence.domain.section.SectionRepository;
+import goorm.eagle7.stelligence.domain.section.model.Section;
+
+/**
+ * UpdateAmendmentMergeTemplate
+ * 수정 타입의 수정안에 대해 병합을 수행합니다.
+ *
+ */
+@Component
+public class UpdateAmendmentMergeTemplate extends AmendmentMergeTemplate {
+
+	public UpdateAmendmentMergeTemplate(SectionRepository sectionRepository) {
+		super(sectionRepository);
+	}
+
+	/**
+	 * 수정안의 정보를 바탕으로 새로운 섹션을 생성합니다.
+	 *
+	 * 수정 타입의 경우, 기존 섹션의 ID를 그대로 사용합니다.
+	 * 기존 섹션 ID와 함께 변경된 내용을 갖는 새로운 섹션을 삽입하는 것으로 완료됩니다.
+	 * 순서는 기존의 순서를 따라야합니다.
+	 * @param document
+	 * @param amendment
+	 * @return
+	 */
+	@Override
+	Section createSection(Document document, Amendment amendment) {
+		return Section.createSection(
+			document,
+			amendment.getTargetSection().getId(), //기존 섹션의 ID를 그대로 사용합니다.
+			document.getCurrentRevision() + 1,
+			amendment.getNewSectionHeading(),
+			amendment.getNewSectionTitle(),
+			amendment.getNewSectionContent(),
+			amendment.getTargetSection().getOrder() // 기존 섹션의 순서를 따릅니다.
+		);
+	}
+
+	@Override
+	void afterMerged(Section section) {
+		//do nothing
+	}
+}

--- a/src/main/java/goorm/eagle7/stelligence/domain/amendment/model/Amendment.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/amendment/model/Amendment.java
@@ -88,4 +88,8 @@ public class Amendment extends BaseTimeEntity {
 		this.targetSection = targetSection;
 		this.status = AmendmentStatus.PENDING;
 	}
+
+	public void setContribute(Contribute contribute) {
+		this.contribute = contribute;
+	}
 }

--- a/src/main/java/goorm/eagle7/stelligence/domain/amendment/model/Amendment.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/amendment/model/Amendment.java
@@ -1,6 +1,7 @@
 package goorm.eagle7.stelligence.domain.amendment.model;
 
 import goorm.eagle7.stelligence.common.entity.BaseTimeEntity;
+import goorm.eagle7.stelligence.domain.contribute.model.Contribute;
 import goorm.eagle7.stelligence.domain.member.model.Member;
 import goorm.eagle7.stelligence.domain.section.model.Heading;
 import goorm.eagle7.stelligence.domain.section.model.Section;
@@ -35,9 +36,9 @@ public class Amendment extends BaseTimeEntity {
 	@JoinColumn(name = "member_id")
 	private Member member;
 
-	// @ManyToOne(fetch = FetchType.LAZY)
-	// @JoinColumn(name = "contribute_id")
-	// private Contribute contribute;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "contribute_id")
+	private Contribute contribute;
 
 	private String amendmentTitle;
 	private String amendmentDescription;

--- a/src/main/java/goorm/eagle7/stelligence/domain/contribute/model/Contribute.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/contribute/model/Contribute.java
@@ -1,0 +1,42 @@
+package goorm.eagle7.stelligence.domain.contribute.model;
+
+import static lombok.AccessLevel.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import goorm.eagle7.stelligence.domain.amendment.model.Amendment;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * Contribute
+ * 투표를 받고 문서 수정의 단위가 되는 수정안의 집합입니다.
+ * 사용자로부터 수정안의 조합을 받아 생성됩니다.
+ */
+@Entity
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class Contribute {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Enumerated(EnumType.STRING)
+	private ContributeStatus status;
+
+	/**
+	 * Contribute가 가지는 수정안들의 목록입니다.
+	 */
+	@OneToMany(mappedBy = "contribute")
+	private List<Amendment> amendments = new ArrayList<>();
+
+}

--- a/src/main/java/goorm/eagle7/stelligence/domain/contribute/model/Contribute.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/contribute/model/Contribute.java
@@ -39,4 +39,11 @@ public class Contribute {
 	@OneToMany(mappedBy = "contribute")
 	private List<Amendment> amendments = new ArrayList<>();
 
+	//===생성===//
+	public static Contribute createContribute() {
+		Contribute contribute = new Contribute();
+		contribute.status = ContributeStatus.VOTING;
+		return contribute;
+	}
+
 }

--- a/src/main/java/goorm/eagle7/stelligence/domain/contribute/model/ContributeStatus.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/contribute/model/ContributeStatus.java
@@ -1,0 +1,27 @@
+package goorm.eagle7.stelligence.domain.contribute.model;
+
+/**
+ * ContributeStatus
+ * Contribute의 상태를 나타내는 enum 클래스입니다.
+ */
+public enum ContributeStatus {
+	/**
+	 * 수정요청이 생성된 뒤 사용자에게 투표를 뱓고 있는 상태이며, 최대 24시간까지 유지됩니다.
+	 */
+	VOTING,
+
+	/**
+	 * 투표 기간이 종료된 후 충분한 투표율을 받지 못하여 토론으로 넘어간 상태입니다.
+	 */
+	DEBATING,
+
+	/**
+	 * 투표 기간이 종료된 후 낮은 투표율로 인하여 수정요청이 거절된 상태입니다.
+	 */
+	REJECTED,
+
+	/**
+	 * 투표 기간이 종료된 후 충분한 투표율로 인하여 수정요청이 반영된 상태입니다.
+	 */
+	MERGED
+}

--- a/src/main/java/goorm/eagle7/stelligence/domain/document/DocumentService.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/document/DocumentService.java
@@ -82,10 +82,14 @@ public class DocumentService {
 	 * 높은 투표율을 받은 Contribute에 대해서 Merge를 진행합니다.
 	 * Contribute를 파라미터로 받아야하지만, 현재 개발되지 않았으므로 임시 파라미터를 받습니다.
 	 *
-	 * 추후 MergeService로 분리될 예정입니다.
+	 * MergeService로 로직이 분리되었습니다.
+	 * 하지만 다른 테스트가 현재 mergeContribute에 의존하고 있으므로
+	 * 테스트 데이터 구축된 이후 없애도록 하겠습니다.
+	 *
 	 * @param documentId
 	 */
 	@Transactional
+	@Deprecated
 	public void mergeContribute(Long documentId, List<Commit> commits) {
 		Document document = documentRepository.findForUpdate(documentId)
 			.orElseThrow(() -> new BaseException("문서가 존재하지 않습니다. 문서 ID : " + documentId));

--- a/src/test/java/goorm/eagle7/stelligence/common/merge/MergeServiceIntegratedTest.java
+++ b/src/test/java/goorm/eagle7/stelligence/common/merge/MergeServiceIntegratedTest.java
@@ -1,0 +1,121 @@
+package goorm.eagle7.stelligence.common.merge;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import goorm.eagle7.stelligence.common.sequence.SectionIdGenerator;
+import goorm.eagle7.stelligence.domain.amendment.model.Amendment;
+import goorm.eagle7.stelligence.domain.amendment.model.AmendmentType;
+import goorm.eagle7.stelligence.domain.contribute.model.Contribute;
+import goorm.eagle7.stelligence.domain.document.model.Document;
+import goorm.eagle7.stelligence.domain.section.model.Heading;
+import goorm.eagle7.stelligence.domain.section.model.Section;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
+@SpringBootTest
+@Transactional
+class MergeServiceIntegratedTest {
+
+	@Autowired
+	MergeService mergeService;
+
+	@PersistenceContext
+	EntityManager em;
+
+	@Autowired
+	SectionIdGenerator sectionIdGenerator;
+
+	@Test
+	void merge() {
+		//given
+		Document document = Document.createDocument("title");
+
+		Section section1 = Section.createSection(
+			document,
+			sectionIdGenerator.getAndIncrementSectionId(),
+			1L,
+			Heading.H1,
+			"title",
+			"content",
+			1
+		);
+
+		Section section2 = Section.createSection(
+			document,
+			sectionIdGenerator.getAndIncrementSectionId(),
+			1L,
+			Heading.H2,
+			"title2",
+			"content2",
+			2
+		);
+
+		Contribute contribute = Contribute.createContribute();
+
+		Amendment amendment1 = new Amendment(
+			null,
+			"amendmentTitle",
+			"amendmentDescription",
+			AmendmentType.CREATE,
+			section1,
+			Heading.H2,
+			"newTitle",
+			"newContent"
+		);
+
+		amendment1.setContribute(contribute);
+
+		Amendment amendment2 = new Amendment(
+			null,
+			"amendmentTitle",
+			"amendmentDescription",
+			AmendmentType.UPDATE,
+			section2,
+			Heading.H2,
+			"updateTitle",
+			"updateContent"
+		);
+
+		amendment2.setContribute(contribute);
+
+		em.persist(document);
+		em.persist(section1);
+		em.persist(section2);
+		em.persist(contribute);
+		em.persist(amendment1);
+		em.persist(amendment2);
+
+		em.flush();
+		em.clear();
+
+		//when
+
+		Document findDocument = em.find(Document.class, document.getId());
+		Contribute findContribute = em.find(Contribute.class, contribute.getId());
+
+		mergeService.merge(findDocument.getId(), findContribute);
+
+		em.flush();
+		em.clear();
+		//then
+
+		Document mergedDocument = em.find(Document.class, document.getId());
+
+		assertThat(mergedDocument.getCurrentRevision()).isEqualTo(2L);
+		assertThat(mergedDocument.getSections()).hasSize(4);
+
+		//Merge 대상 섹션은 새로 생성되어야 하며, revision이 증가해야 한다.
+		Section updatedSection = mergedDocument.getSections().get(2);
+		Section insertedSection = mergedDocument.getSections().get(3);
+		assertThat(updatedSection.getRevision()).isEqualTo(2);
+		assertThat(updatedSection.getId()).isEqualTo(section2.getId());
+		assertThat(insertedSection.getRevision()).isEqualTo(2);
+		assertThat(insertedSection.getId()).isEqualTo(3L);
+
+	}
+}

--- a/src/test/java/goorm/eagle7/stelligence/common/merge/MergeServiceIntegratedTest.java
+++ b/src/test/java/goorm/eagle7/stelligence/common/merge/MergeServiceIntegratedTest.java
@@ -94,7 +94,6 @@ class MergeServiceIntegratedTest {
 		em.clear();
 
 		//when
-
 		Document findDocument = em.find(Document.class, document.getId());
 		Contribute findContribute = em.find(Contribute.class, contribute.getId());
 
@@ -102,8 +101,8 @@ class MergeServiceIntegratedTest {
 
 		em.flush();
 		em.clear();
-		//then
 
+		//then
 		Document mergedDocument = em.find(Document.class, document.getId());
 
 		assertThat(mergedDocument.getCurrentRevision()).isEqualTo(2L);


### PR DESCRIPTION
## 변경 내용 

- DocumentService의 mergeContribute를 별도의 서비스로 옮겼습니다.
- 주요 사항은 다음과 같습니다.
  - MergeService 개발 : MergeService는 배치로부터 호출되어 수정안을 반영하는 역할을 합니다.
  - AmendmentMergeTemplate : 각각의 반영에 대해 공통적인 역할과 수정안 타입에 따른 세부적인 역할을 분리할 수 있도록 합니다. 또한 각각의 반영에 대한 코드를 분리하여 가독성을 높였고 추후 타입 추가에 대해 열려있게 만들었습니다.

## 특이 사항
- 필요에 의해 Contribute 엔티티를 생성했습니다.
- 필요에 의해 Amendment 엔티티에 코드를 추가했습니다. 은지님은 확인하신 뒤 머지 부탁드립니다.

## 체크리스트

- [x] PR 날리기 전에 main branch pull 받으셨나요?
- [x] application.properties 등 노출되지 않아야 하는 파일이 올라가지는 않았나요?
- [x] 다른 담당자 파일을 수정한 부분에 대해서 이야기 하셨나요? : 예 은지님한테 전달했습니다. 충돌사항 없을 것으로 예상됩니다.
- [x] 주석 "상세히" 다셨나요?
