### PR TITLE
26 datajpatest h2 error

### DIFF
--- a/src/test/java/goorm/eagle7/stelligence/common/entity/BaseTimeEntityTest.java
+++ b/src/test/java/goorm/eagle7/stelligence/common/entity/BaseTimeEntityTest.java
@@ -24,7 +24,7 @@ class BaseTimeEntityTest {
 	private EntityManager em;
 
 	@Entity
-	public static class TestEntity extends BaseTimeEntity {
+	static class TestEntity extends BaseTimeEntity {
 		@Id
 		Long id;
 		String val;

--- a/src/test/java/goorm/eagle7/stelligence/common/entity/BaseTimeEntityTest.java
+++ b/src/test/java/goorm/eagle7/stelligence/common/entity/BaseTimeEntityTest.java
@@ -2,7 +2,6 @@ package goorm.eagle7.stelligence.common.entity;
 
 import static org.assertj.core.api.Assertions.*;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
@@ -18,7 +17,6 @@ import jakarta.persistence.PersistenceContext;
  * TimeAuditing이 잘 동작하는지 테스트합니다.
  */
 @DataJpaTest
-@Disabled
 @Import(JpaAuditingConfig.class)
 class BaseTimeEntityTest {
 
@@ -26,7 +24,7 @@ class BaseTimeEntityTest {
 	private EntityManager em;
 
 	@Entity
-	static class TestEntity extends BaseTimeEntity {
+	public static class TestEntity extends BaseTimeEntity {
 		@Id
 		Long id;
 		String val;

--- a/src/test/java/goorm/eagle7/stelligence/domain/section/SectionRepositoryTest.java
+++ b/src/test/java/goorm/eagle7/stelligence/domain/section/SectionRepositoryTest.java
@@ -5,12 +5,12 @@ import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
 import goorm.eagle7.stelligence.config.mockdata.WithMockData;
 import goorm.eagle7.stelligence.domain.section.model.Section;
 
-@SpringBootTest
+@DataJpaTest
 @WithMockData
 class SectionRepositoryTest {
 

--- a/src/test/resources/dummy.sql
+++ b/src/test/resources/dummy.sql
@@ -45,7 +45,7 @@ values (1, 1, 1, 'H1', 'document1_title1', 'document1_content1', 1, NOW(), NOW()
        (12, 1, 4, 'H3', 'document4_title3', 'document4_content3', 3, NOW(), NOW());
 
 -- SectionId의 sequence_Id는 15부터
-INSERT sequence_table (sequence_name, sequence_value)
+INSERT into sequence_table (sequence_name, sequence_value)
 values ('section', 15);
 
 


### PR DESCRIPTION
## 변경 내용 

- @DataJpaTest시 자동으로 H2를 사용하는데, 이 때에 dialect 때문에 에러가 발생했던 것을 파악했습니다.
- 아래 내용을 반영한 뒤 @DataJpaTest가 적절한 테스트에는 @DataJpaTest를 반영해 주었습니다.
- dummy.sql에 into가 빠져있었던 부분을 수정했습니다.

## 특이 사항

- 테스트의 application.properties에 혹시 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect 가 있다면 삭제하면 좋을 것 같습니다.

## 체크리스트

- [x] PR 날리기 전에 main branch pull 받으셨나요?
- [x] application.properties 등 노출되지 않아야 하는 파일이 올라가지는 않았나요?
- [x] 다른 담당자 파일을 수정한 부분에 대해서 이야기 하셨나요?
- [x] 주석 "상세히" 다셨나요?
- [x] 제출하기 전에 테스트코드 돌려 보셨나요?

closes #26
