### PR TITLE
28 문서 그래프에서 제목으로 문서 검색 기능

### DIFF
--- a/src/main/java/goorm/eagle7/stelligence/api/DatabaseConnectionApplicationRunner.java
+++ b/src/main/java/goorm/eagle7/stelligence/api/DatabaseConnectionApplicationRunner.java
@@ -64,13 +64,15 @@ public class DatabaseConnectionApplicationRunner implements ApplicationRunner {
 			log.error("Error testing Neo4j connection: " + e.getMessage());
 		}
 
+		// neo4j의 fulltextindex를 체크하는 로직
 		try {
+			// `fulltext.analyzer`: 'cjk'는 중/일/한국어 특화 분석기
+			// `fulltext.eventually_consistent`: false : 삽입에 대해 인덱싱을 지연하지 않고 즉시 적용
 			String neo4jFulltextIndexQuery = "create fulltext index documentTitleIndex"
 				+ " if not exists for (n:DocumentNode) on each [n.title]"
 				+ " OPTIONS {"
 				+ "  indexConfig: {"
-				+ "    `fulltext.analyzer`: 'cjk',"
-				+ "    `fulltext.eventually_consistent`: true"
+				+ "    `fulltext.analyzer`: 'cjk', `fulltext.eventually_consistent`: false"
 				+ "  }"
 				+ " };";
 			neo4jClient.query(neo4jFulltextIndexQuery).run();

--- a/src/main/java/goorm/eagle7/stelligence/api/DatabaseConnectionApplicationRunner.java
+++ b/src/main/java/goorm/eagle7/stelligence/api/DatabaseConnectionApplicationRunner.java
@@ -63,6 +63,21 @@ public class DatabaseConnectionApplicationRunner implements ApplicationRunner {
 		} catch (Exception e) {
 			log.error("Error testing Neo4j connection: " + e.getMessage());
 		}
+
+		try {
+			String neo4jFulltextIndexQuery = "create fulltext index documentTitleIndex"
+				+ " if not exists for (n:DocumentNode) on each [n.title]"
+				+ " OPTIONS {"
+				+ "  indexConfig: {"
+				+ "    `fulltext.analyzer`: 'cjk',"
+				+ "    `fulltext.eventually_consistent`: true"
+				+ "  }"
+				+ " };";
+			neo4jClient.query(neo4jFulltextIndexQuery).run();
+			log.info("Neo4j fulltext index has checked successful.");
+		} catch (Exception e) {
+			log.error("Error checking Neo4j fulltext index: " + e.getMessage());
+		}
 	}
 
 }

--- a/src/main/java/goorm/eagle7/stelligence/domain/document/graph/DocumentGraphService.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/document/graph/DocumentGraphService.java
@@ -81,7 +81,7 @@ public class DocumentGraphService {
 	 * 특정 제목으로 문서를 검색합니다.
 	 * @param title: 검색할 제목을 나타냅니다.
 	 * @param limit: 최대로 검색할 노드의 개수를 나타냅니다.
-	 * @return DocumentNodeResponse: 문서 노드에 대한 응답입니다.
+	 * @return List&lt;DocumentNodeResponse&gt;: 문서 노드에 대한 응답입니다.
 	 */
 	public List<DocumentNodeResponse> findNodeByTitle(String title, int limit) {
 
@@ -91,7 +91,7 @@ public class DocumentGraphService {
 	/**
 	 * documentId의 리스트와 일치하는 문서들을 검색합니다.
 	 * @param documentIdList: 검색할 문서들의 id들을 담은 리스트입니다.
-	 * @return List<DocumentNodeResponse>: 문서 노드에 대한 응답입니다.
+	 * @return List&lt;DocumentNodeResponse&gt;: 문서 노드에 대한 응답입니다.
 	 */
 	public List<DocumentNodeResponse> findNodeByDocumentId(List<Long> documentIdList) {
 

--- a/src/main/java/goorm/eagle7/stelligence/domain/document/graph/DocumentGraphService.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/document/graph/DocumentGraphService.java
@@ -77,7 +77,12 @@ public class DocumentGraphService {
 		return DocumentGraphResponse.of(documentNodes, hasChildRelationshipList);
 	}
 
-
+	/**
+	 * 특정 제목으로 문서를 검색합니다.
+	 * @param title: 검색할 제목을 나타냅니다.
+	 * @param limit: 최대로 검색할 노드의 개수를 나타냅니다.
+	 * @return DocumentNodeResponse: 문서 노드에 대한 응답입니다.
+	 */
 	public List<DocumentNodeResponse> findNodeByTitle(String title, int limit) {
 
 		return documentNodeRepository.findNodeByTitle(title, limit);

--- a/src/main/java/goorm/eagle7/stelligence/domain/document/graph/DocumentGraphService.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/document/graph/DocumentGraphService.java
@@ -87,4 +87,14 @@ public class DocumentGraphService {
 
 		return documentNodeRepository.findNodeByTitle(title, limit);
 	}
+
+	/**
+	 * documentId의 리스트와 일치하는 문서들을 검색합니다.
+	 * @param documentIdList: 검색할 문서들의 id들을 담은 리스트입니다.
+	 * @return List<DocumentNodeResponse>: 문서 노드에 대한 응답입니다.
+	 */
+	public List<DocumentNodeResponse> findNodeByDocumentId(List<Long> documentIdList) {
+
+		return documentNodeRepository.findNodeByDocumentId(documentIdList);
+	}
 }

--- a/src/main/java/goorm/eagle7/stelligence/domain/document/graph/DocumentGraphService.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/document/graph/DocumentGraphService.java
@@ -76,4 +76,10 @@ public class DocumentGraphService {
 
 		return DocumentGraphResponse.of(documentNodes, hasChildRelationshipList);
 	}
+
+
+	public List<DocumentNodeResponse> findNodeByTitle(String title, int limit) {
+
+		return documentNodeRepository.findNodeByTitle(title, limit);
+	}
 }

--- a/src/main/java/goorm/eagle7/stelligence/domain/document/graph/DocumentNodeRepository.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/document/graph/DocumentNodeRepository.java
@@ -36,7 +36,7 @@ public interface DocumentNodeRepository extends Neo4jRepository<DocumentNode, Lo
 
 
 	// @Query("match (n:DocumentNode) where n.title contains $title return n.documentId, n.title, n.group limit $limit")
-	@Query("call db.index.fulltext.queryNodes('documentTitleIndex', $title+'~', {limit: :#{literal(#limit)}, sortBy: 'score'})"
+	@Query("call db.index.fulltext.queryNodes('documentTitleIndex', '*'+$title+'*', {limit: :#{literal(#limit)}, sortBy: 'score'})"
 		+ " yield node, score"
 		+ " where score > 0"
 		+ " return node.documentId as documentId, node.title as title, node.group as group")

--- a/src/main/java/goorm/eagle7/stelligence/domain/document/graph/DocumentNodeRepository.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/document/graph/DocumentNodeRepository.java
@@ -33,4 +33,13 @@ public interface DocumentNodeRepository extends Neo4jRepository<DocumentNode, Lo
 		+ " where n1.documentId=$documentId"
 		+ " return id(r[-1]) as linkId, startNode(r[-1]).documentId as parentDocumentId, endNode(r[-1]).documentId as childDocumentId")
 	List<HasChildRelationshipResponse> findHasChildRelationshipByDocumentIdWithDepth(@Param("documentId") Long documentId, @Param("depth") int depth);
+
+
+	// @Query("match (n:DocumentNode) where n.title contains $title return n.documentId, n.title, n.group limit $limit")
+	@Query("call db.index.fulltext.queryNodes('documentTitleIndex', $title+'~', {limit: :#{literal(#limit)}, sortBy: 'score'})"
+		+ " yield node, score"
+		+ " where score > 0"
+		+ " return node.documentId, node.title, node.group")
+	List<DocumentNodeResponse> findNodeByTitle(@Param("title") String title, @Param("limit") int limit);
+
 }

--- a/src/main/java/goorm/eagle7/stelligence/domain/document/graph/DocumentNodeRepository.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/document/graph/DocumentNodeRepository.java
@@ -42,4 +42,8 @@ public interface DocumentNodeRepository extends Neo4jRepository<DocumentNode, Lo
 		+ " return node.documentId as documentId, node.title as title, node.group as group")
 	List<DocumentNodeResponse> findNodeByTitle(@Param("title") String title, @Param("limit") int limit);
 
+	@Query("match (n:DocumentNode)"
+		+ " where n.documentId in $idList"
+		+ " return n.documentId as documentId, n.title as title, n.group as group")
+	List<DocumentNodeResponse> findNodeByDocumentId(@Param("idList") List<Long> documentIdList);
 }

--- a/src/main/java/goorm/eagle7/stelligence/domain/document/graph/DocumentNodeRepository.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/document/graph/DocumentNodeRepository.java
@@ -39,7 +39,7 @@ public interface DocumentNodeRepository extends Neo4jRepository<DocumentNode, Lo
 	@Query("call db.index.fulltext.queryNodes('documentTitleIndex', $title+'~', {limit: :#{literal(#limit)}, sortBy: 'score'})"
 		+ " yield node, score"
 		+ " where score > 0"
-		+ " return node.documentId, node.title, node.group")
+		+ " return node.documentId as documentId, node.title as title, node.group as group")
 	List<DocumentNodeResponse> findNodeByTitle(@Param("title") String title, @Param("limit") int limit);
 
 }

--- a/src/main/java/goorm/eagle7/stelligence/domain/document/graph/dto/DocumentNodeResponse.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/document/graph/dto/DocumentNodeResponse.java
@@ -3,9 +3,11 @@ package goorm.eagle7.stelligence.domain.document.graph.dto;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
+@ToString
 public class DocumentNodeResponse {
 
 	private Long documentId;

--- a/src/test/java/goorm/eagle7/stelligence/domain/document/graph/DocumentGraphServiceTest.java
+++ b/src/test/java/goorm/eagle7/stelligence/domain/document/graph/DocumentGraphServiceTest.java
@@ -14,8 +14,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import goorm.eagle7.stelligence.domain.document.content.DocumentRepository;
 import goorm.eagle7.stelligence.domain.document.content.model.Document;
-import goorm.eagle7.stelligence.domain.document.graph.DocumentGraphService;
-import goorm.eagle7.stelligence.domain.document.graph.DocumentNodeRepository;
 import goorm.eagle7.stelligence.domain.document.graph.dto.DocumentGraphResponse;
 import goorm.eagle7.stelligence.domain.document.graph.dto.DocumentNodeResponse;
 import goorm.eagle7.stelligence.domain.document.graph.dto.HasChildRelationshipResponse;

--- a/src/test/java/goorm/eagle7/stelligence/domain/document/graph/DocumentNodeRepositoryTest.java
+++ b/src/test/java/goorm/eagle7/stelligence/domain/document/graph/DocumentNodeRepositoryTest.java
@@ -2,15 +2,17 @@ package goorm.eagle7.stelligence.domain.document.graph;
 
 import static org.assertj.core.api.Assertions.*;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.neo4j.core.Neo4jClient;
 import org.springframework.transaction.annotation.Transactional;
 
-import goorm.eagle7.stelligence.domain.document.graph.DocumentNodeRepository;
+import goorm.eagle7.stelligence.domain.document.graph.dto.DocumentNodeResponse;
 import goorm.eagle7.stelligence.domain.document.graph.model.DocumentNode;
 import lombok.extern.slf4j.Slf4j;
 
@@ -21,6 +23,8 @@ class DocumentNodeRepositoryTest {
 
 	@Autowired
 	private DocumentNodeRepository documentNodeRepository;
+	@Autowired
+	Neo4jClient neo4jClient;
 
 	@Test
 	@DisplayName("문서 노드 단일 저장 테스트")
@@ -140,5 +144,119 @@ class DocumentNodeRepositoryTest {
 		assertThat(findDocumentNode.getDocumentId()).isEqualTo(grandChildDocumentId);
 		assertThat(findDocumentNode.getTitle()).isEqualTo(grandChildTitle);
 		assertThat(findDocumentNode.getGroup()).isEqualTo(parentNode.getGroup());
+	}
+
+	@Test
+	@DisplayName("특정 제목으로 검색하면 해당 제목이 포함된 경우에만 반환")
+	void findNodeByTitle() {
+
+		//given
+		final String searchTitle = "title1";
+		final int limit = 5;
+
+		String[] queries = queriesThatMakesThreeNodesWithDepthFour();
+
+		for (String queryString : queries) {
+			neo4jClient.query(queryString).run();
+		}
+
+		//when
+		List<DocumentNodeResponse> findNodes = documentNodeRepository.findNodeByTitle(searchTitle, limit);
+
+		//then
+		log.info("findNodes: {}", findNodes);
+		List<String> titleList = findNodes.stream().map(DocumentNodeResponse::getTitle).toList();
+		assertThat(titleList)
+			.isNotEmpty()
+			.allMatch(s -> s.contains(searchTitle));
+	}
+
+	@Test
+	@DisplayName("존재하지 않는 제목으로 검색하면 결과가 빈 리스트로 반환")
+	void findNoNodeByTitle() {
+
+		//given
+		final String searchTitle = "대충검색이될수없는이상한검색어";
+		final int limit = 5;
+
+		String[] queries = queriesThatMakesThreeNodesWithDepthFour();
+
+		for (String queryString : queries) {
+			neo4jClient.query(queryString).run();
+		}
+
+		//when
+		List<DocumentNodeResponse> findNodes = documentNodeRepository.findNodeByTitle(searchTitle, limit);
+
+		//then
+		log.info("findNodes: {}", findNodes);
+		List<String> titleList = findNodes.stream().map(DocumentNodeResponse::getTitle).toList();
+		assertThat(titleList)
+			.isEmpty();
+	}
+
+	@Test
+	@DisplayName("한국어 제목으로도 검색이 잘 됨")
+	void findKoreanNodeByTitle() {
+
+		//given
+		final String searchTitle = "제목";
+		final int limit = 5;
+
+		String[] queries = queriesThatMakesNodeInKorean();
+
+		for (String queryString : queries) {
+			neo4jClient.query(queryString).run();
+		}
+
+		//when
+		List<DocumentNodeResponse> findNodes = documentNodeRepository.findNodeByTitle(searchTitle, limit);
+
+		//then
+		log.info("findNodes: {}", findNodes);
+		List<String> titleList = findNodes.stream().map(DocumentNodeResponse::getTitle).toList();
+		assertThat(titleList)
+			.isNotEmpty()
+			.allMatch(s -> s.contains(searchTitle));
+	}
+
+	private static String[] queriesThatMakesThreeNodesWithDepthFour() {
+		return new String[] {
+			"CREATE (:DocumentNode {documentId: 1, level: 2, title: 'title1', group: 'title1'}),"
+				+ "       (:DocumentNode {documentId: 2, level: 2, title: 'title2', group: 'title2'}),"
+				+ "       (:DocumentNode {documentId: 3, level: 2, title: 'title3', group: 'title3'});",
+			"MATCH (p2:DocumentNode {level: 2})"
+				+ " WITH p2"
+				+ " CREATE (p2)-[:HAS_CHILD]->(:DocumentNode {documentId: p2.documentId * 10 + 1, level: 3, title: 'title' + toString(p2.documentId * 10 + 1), group: p2.group}),"
+				+ "       (p2)-[:HAS_CHILD]->(:DocumentNode {documentId: p2.documentId * 10 + 2, level: 3, title: 'title' + toString(p2.documentId * 10 + 2), group: p2.group}),"
+				+ "       (p2)-[:HAS_CHILD]->(:DocumentNode {documentId: p2.documentId * 10 + 3, level: 3, title: 'title' + toString(p2.documentId * 10 + 3), group: p2.group});",
+			"MATCH (p3:DocumentNode {level: 3})"
+				+ " WITH p3"
+				+ " CREATE (p3)-[:HAS_CHILD]->(:DocumentNode {documentId: p3.documentId * 10 + 1, level: 4, title: 'title' + toString(p3.documentId * 10 + 1), group: p3.group}),"
+				+ "       (p3)-[:HAS_CHILD]->(:DocumentNode {documentId: p3.documentId * 10 + 2, level: 4, title: 'title' + toString(p3.documentId * 10 + 2), group: p3.group}),"
+				+ "       (p3)-[:HAS_CHILD]->(:DocumentNode {documentId: p3.documentId * 10 + 3, level: 4, title: 'title' + toString(p3.documentId * 10 + 3), group: p3.group});",
+			" MATCH (p4:DocumentNode {level: 4})"
+				+ " WITH p4"
+				+ " CREATE (p4)-[:HAS_CHILD]->(:DocumentNode {documentId: p4.documentId * 10 + 1, level: 5, title: 'title' + toString(p4.documentId * 10 + 1), group: p4.group}),"
+				+ "       (p4)-[:HAS_CHILD]->(:DocumentNode {documentId: p4.documentId * 10 + 2, level: 5, title: 'title' + toString(p4.documentId * 10 + 2), group: p4.group}),"
+				+ "       (p4)-[:HAS_CHILD]->(:DocumentNode {documentId: p4.documentId * 10 + 3, level: 5, title: 'title' + toString(p4.documentId * 10 + 3), group: p4.group});",
+			"MATCH (n:DocumentNode)"
+				+ " SET n.level = NULL;"
+		};
+	}
+
+	private static String[] queriesThatMakesNodeInKorean() {
+		return new String[] {
+			"CREATE (:DocumentNode {documentId: 1, title: '제목', group: '제목'}),"
+				+ " (:DocumentNode {documentId: 2, title: '제목찾기', group: '제목찾기'}),"
+				+ " (:DocumentNode {documentId: 3, title: '제목검색', group: '제목검색'}),"
+				+ " (:DocumentNode {documentId: 4, title: '목재', group: '목재'}),"
+				+ " (:DocumentNode {documentId: 5, title: '제목과 목차', group: '제목과 목차'}),"
+				+ " (:DocumentNode {documentId: 6, title: '제목예시', group: '제목예시'}),"
+				+ " (:DocumentNode {documentId: 7, title: '제 목', group: '제 목'}),"
+				+ " (:DocumentNode {documentId: 8, title: '제몫', group: '제몫'}),"
+				+ " (:DocumentNode {documentId: 9, title: '제모', group: '제모'}),"
+				+ " (:DocumentNode {documentId: 10, title: '제뭐임', group: '제뭐임'});"
+		};
 	}
 }

--- a/src/test/java/goorm/eagle7/stelligence/domain/document/graph/DocumentNodeRepositoryTest.java
+++ b/src/test/java/goorm/eagle7/stelligence/domain/document/graph/DocumentNodeRepositoryTest.java
@@ -2,6 +2,7 @@ package goorm.eagle7.stelligence.domain.document.graph;
 
 import static org.assertj.core.api.Assertions.*;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -218,6 +219,33 @@ class DocumentNodeRepositoryTest {
 		assertThat(titleList)
 			.isNotEmpty()
 			.allMatch(s -> s.contains(searchTitle));
+	}
+
+	@Test
+	@DisplayName("documentId의 리스트로 문서 노드들 검색")
+	void findNodeByDocumentId() {
+		//given
+		final List<Long> searchDocumentIdList = new ArrayList<>();
+		searchDocumentIdList.add(1L);
+		searchDocumentIdList.add(2L);
+		searchDocumentIdList.add(3L);
+
+		String[] queries = queriesThatMakesThreeNodesWithDepthFour();
+
+		for (String queryString : queries) {
+			neo4jClient.query(queryString).run();
+		}
+
+		//when
+		List<DocumentNodeResponse> findNodes = documentNodeRepository.findNodeByDocumentId(searchDocumentIdList);
+
+		//then
+		log.info("findNodes: {}", findNodes);
+		List<Long> findDocumentIdList = findNodes.stream().map(DocumentNodeResponse::getDocumentId).toList();
+		assertThat(findDocumentIdList)
+			.isNotEmpty()
+			.hasSize(3)
+			.containsAll(searchDocumentIdList);
 	}
 
 	private static String[] queriesThatMakesThreeNodesWithDepthFour() {


### PR DESCRIPTION
## 변경 내용 

- 제목으로 노드를 검색하는 기능을 추가했습니다.  (문서 별 반짝반짝이나, 글 작성시 링크 연결 등에 사용 예정)
    - 위 기능을 안정적으로 지원하기 위해 애플리케이션 실행 시점에 검색을 위한 인덱스 설정이 완료되어있는지 확인합니다.
- 문서 id들로 노드를 검색하는 기능을 추가했습니다. (DocumentContentService와 연계하여 내용으로 검색에 활용)

## 특이 사항

- 추후 비즈니스 요구사항에 따라 제목 검색 방식이 부분 일치 검색(*)이 아닌, 유사도 기반 검색(~)으로 변경될 수 있습니다.
- 추후 제목 검색에 활용된 fulltext index의 옵션을 eventually_consistent로 설정하게 될 수 있습니다.
    - 이때는 노드 생성/수정에 대해 인덱스가 즉시 반영되지 않지만, 가용성을 높일 수 있어서 잘 고려해봐야할 것 같습니다.

## 체크리스트

- [x] PR 날리기 전에 main branch pull 받으셨나요?
- [x] application.properties 등 노출되지 않아야 하는 파일이 올라가지는 않았나요?
- [x] 다른 담당자 파일을 수정한 부분에 대해서 이야기 하셨나요?
- [x] 주석 "상세히" 다셨나요?
- [x] 제출하기 전에 테스트코드 돌려 보셨나요?

closes #
