### PR TITLE
39 rediscache 설정 및 문서 조회시 캐싱

### DIFF
--- a/src/main/java/goorm/eagle7/stelligence/config/RedisConfig.java
+++ b/src/main/java/goorm/eagle7/stelligence/config/RedisConfig.java
@@ -1,0 +1,48 @@
+package goorm.eagle7.stelligence.config;
+
+import static org.springframework.data.redis.serializer.RedisSerializationContext.SerializationPair.*;
+
+import java.time.Duration;
+
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.cache.RedisCacheWriter;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+/**
+ * Redis와 Cache 관련 설정 클래스입니다.
+ */
+@Configuration
+@EnableCaching
+public class RedisConfig {
+
+	private static final int DEFAULT_EXPIRE_SEC = 60 * 5; // 캐시는 5분동안 유효합니다.
+
+	@Bean
+	public RedisConnectionFactory redisConnectionFactory() {
+		return new LettuceConnectionFactory();
+	}
+
+	@Bean
+	public RedisCacheManager cacheManager() {
+		return RedisCacheManager.builder(
+				RedisCacheWriter.lockingRedisCacheWriter(redisConnectionFactory())) //locking을 통해 캐시의 일관성을 보장
+			.cacheDefaults(cacheConfiguration()) // 캐시 기본 설정
+			.transactionAware() //Redis의 동작을 Spring이 관리하는 트랜잭션과 동기화
+			.build();
+	}
+
+	private RedisCacheConfiguration cacheConfiguration() {
+		return RedisCacheConfiguration.defaultCacheConfig()
+			.serializeKeysWith(fromSerializer(new StringRedisSerializer()))
+			.serializeValuesWith(fromSerializer(new GenericJackson2JsonRedisSerializer())) //객체 직렬화에 Jackson을 사용
+			.entryTtl(Duration.ofSeconds(DEFAULT_EXPIRE_SEC)) //DEFAULT_EXPIRE_SEC 만큼 캐시 유지
+			.disableCachingNullValues();
+	}
+}

--- a/src/main/java/goorm/eagle7/stelligence/domain/document/content/DocumentContentService.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/document/content/DocumentContentService.java
@@ -2,6 +2,7 @@ package goorm.eagle7.stelligence.domain.document.content;
 
 import java.util.List;
 
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -173,6 +174,7 @@ public class DocumentContentService {
 	/**
 	 * Document의 특정 버전을 조회합니다.
 	 */
+	@Cacheable(value = "document", key = "#documentId + ':' + #revision", cacheManager = "cacheManager")
 	public DocumentResponse getDocument(Long documentId, Long revision) {
 
 		//문서가 존재하는지 확인합니다.

--- a/src/main/java/goorm/eagle7/stelligence/domain/document/content/dto/DocumentResponse.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/document/content/dto/DocumentResponse.java
@@ -3,13 +3,16 @@ package goorm.eagle7.stelligence.domain.document.content.dto;
 import java.util.List;
 
 import goorm.eagle7.stelligence.domain.document.content.model.Document;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 /**
  * Document 응답 DTO 입니다.
  * Document의 정보와 Section의 정보를 담습니다.
  */
 @Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class DocumentResponse {
 
 	private Long documentId;

--- a/src/main/java/goorm/eagle7/stelligence/domain/document/content/dto/SectionResponse.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/document/content/dto/SectionResponse.java
@@ -2,16 +2,19 @@ package goorm.eagle7.stelligence.domain.document.content.dto;
 
 import goorm.eagle7.stelligence.domain.section.model.Heading;
 import goorm.eagle7.stelligence.domain.section.model.Section;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 /**
  * Section의 정보를 담기 위한 응답 DTO입니다.
  */
+@Getter
 @ToString
 @AllArgsConstructor
-@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class SectionResponse {
 
 	private Long sectionId;

--- a/src/test/java/goorm/eagle7/stelligence/domain/document/content/DocumentContentServiceCachingTest.java
+++ b/src/test/java/goorm/eagle7/stelligence/domain/document/content/DocumentContentServiceCachingTest.java
@@ -1,0 +1,66 @@
+package goorm.eagle7.stelligence.domain.document.content;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.context.transaction.TestTransaction;
+import org.springframework.transaction.annotation.Transactional;
+
+import goorm.eagle7.stelligence.config.mockdata.WithMockData;
+import goorm.eagle7.stelligence.domain.document.content.dto.DocumentResponse;
+import goorm.eagle7.stelligence.domain.document.content.model.Document;
+import goorm.eagle7.stelligence.domain.section.SectionRepository;
+
+@SpringBootTest
+@Transactional
+@WithMockData
+class DocumentContentServiceCachingTest {
+
+	@Autowired
+	private DocumentContentService documentContentService;
+
+	@Autowired
+	private RedisTemplate<String, String> redisTemplate;
+
+	@MockBean
+	private SectionRepository sectionRepository;
+
+	@AfterEach
+	void tearDown() {
+		//clear cache
+		redisTemplate.delete("document::1:3");
+	}
+
+	@Test
+	@DisplayName("캐싱 테스트")
+	void cacheTest() {
+
+		//문서 조회
+		DocumentResponse documentResponse = documentContentService.getDocument(1L, 3L);
+
+		TestTransaction.flagForCommit();
+		TestTransaction.end(); //트랜잭션 종료를 통한 캐싱 반영
+
+		//새 트랜잭션에서 문서 조회 : 캐싱 결과값 가져오기
+		TestTransaction.start();
+
+		DocumentResponse documentResponse2 = documentContentService.getDocument(1L, 3L);
+
+		TestTransaction.flagForCommit();
+		TestTransaction.end();
+
+		//쿼리가 1번만 나갔는지 검증
+		verify(sectionRepository, times(1)).findByVersion(any(Document.class), any(Long.class));
+
+		//캐싱된 값이 같은지 검증
+		assertThat(documentResponse.getDocumentId()).isEqualTo(documentResponse2.getDocumentId());
+	}
+
+}


### PR DESCRIPTION
## 변경 내용 

- 스프링의 캐시 추상화 기능을 사용하여 getDocument를 캐시로 처리합니다.
  - 특정 버전의 게시글의 경우 데이터의 변경에 따른 변화가 없기 때문에, 캐싱처리하여도 일관성이 유지됩니다.  

## 특이 사항

- 

## 체크리스트

- [x] PR 날리기 전에 main branch pull 받으셨나요?
- [x] application.properties 등 노출되지 않아야 하는 파일이 올라가지는 않았나요?
- [x] 다른 담당자 파일을 수정한 부분에 대해서 이야기 하셨나요?
- [x] 주석 "상세히" 다셨나요?
- [x] 제출하기 전에 테스트코드 돌려 보셨나요?

closes #39 
