### PR TITLE
60 document api markdown text

### DIFF
--- a/src/main/java/goorm/eagle7/stelligence/domain/document/content/dto/DocumentResponse.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/document/content/dto/DocumentResponse.java
@@ -3,6 +3,7 @@ package goorm.eagle7.stelligence.domain.document.content.dto;
 import java.util.List;
 
 import goorm.eagle7.stelligence.domain.document.content.model.Document;
+import goorm.eagle7.stelligence.domain.document.content.parser.SectionResponseConcatenator;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -18,11 +19,21 @@ public class DocumentResponse {
 	private Long documentId;
 	private String title;
 	private List<SectionResponse> sections;
+	
+	/**
+	 * Document의 모든 섹션의 내용을 하나의 문자열로 합친 내용입니다.
+	 * 사용자가 글 조회시 프론트엔드에서 섹션의 내용을 하나의 문자열로 합쳐서 보여주기 편리하게 만듦니다.
+	 *
+	 * sections에서 파생되는 정보기 때문에 캐싱의 대상으로 삼지 않습니다.
+	 * 매번 요청시 새로 계산해서 반환합니다.
+	 */
+	private String content;
 
 	private DocumentResponse(Long documentId, String title, List<SectionResponse> sections) {
 		this.documentId = documentId;
 		this.title = title;
 		this.sections = sections;
+		this.content = SectionResponseConcatenator.concat(sections);
 	}
 
 	/**

--- a/src/main/java/goorm/eagle7/stelligence/domain/document/content/dto/SectionResponse.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/document/content/dto/SectionResponse.java
@@ -44,4 +44,12 @@ public class SectionResponse {
 	public static SectionResponse of(Long sectionId, Long revision, Heading heading, String title, String content) {
 		return new SectionResponse(sectionId, revision, heading, title, content);
 	}
+
+	/**
+	 * 섹션의 내용을 하나의 문자열로 합칩니다.
+	 * @return
+	 */
+	public String getFullContentString() {
+		return heading.getSymbol() + " " + title + "\n" + content;
+	}
 }

--- a/src/main/java/goorm/eagle7/stelligence/domain/document/content/dto/SectionResponse.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/document/content/dto/SectionResponse.java
@@ -1,5 +1,7 @@
 package goorm.eagle7.stelligence.domain.document.content.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import goorm.eagle7.stelligence.domain.section.model.Heading;
 import goorm.eagle7.stelligence.domain.section.model.Section;
 import lombok.AccessLevel;
@@ -49,6 +51,7 @@ public class SectionResponse {
 	 * 섹션의 내용을 하나의 문자열로 합칩니다.
 	 * @return
 	 */
+	@JsonIgnore
 	public String getFullContentString() {
 		return heading.getSymbol() + " " + title + "\n" + content;
 	}

--- a/src/main/java/goorm/eagle7/stelligence/domain/document/content/parser/SectionResponseConcatenator.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/document/content/parser/SectionResponseConcatenator.java
@@ -1,0 +1,32 @@
+package goorm.eagle7.stelligence.domain.document.content.parser;
+
+import java.util.List;
+
+import goorm.eagle7.stelligence.domain.document.content.dto.SectionResponse;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * SectionResponse로부터 섹션의 내용을 하나의 문자열로 합치는 클래스입니다.
+ *
+ * 사용자가 글 조회시 프론트엔드에서 섹션의 내용을 하나의 문자열로 합쳐서 보여주기 편리하게 만듦니다.
+ * 물론 이때에도 Section 관련 정보는 함께 제공되어 사용자측에서 유연하게 사용할 수 있게 할 예정입니다.
+ *
+ */
+@Slf4j
+public class SectionResponseConcatenator {
+
+	private SectionResponseConcatenator() {
+		throw new IllegalStateException("Utility class");
+	}
+
+	/**
+	 * SectionResponse로부터 섹션의 내용을 하나의 문자열로 합칩니다.
+	 * @param sections
+	 * @return
+	 */
+	public static String concat(List<SectionResponse> sections) {
+		StringBuilder sb = new StringBuilder();
+		sections.forEach(section -> sb.append(section.getFullContentString()));
+		return sb.toString();
+	}
+}

--- a/src/main/java/goorm/eagle7/stelligence/domain/section/model/Heading.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/section/model/Heading.java
@@ -1,8 +1,22 @@
 package goorm.eagle7.stelligence.domain.section.model;
 
+import lombok.Getter;
+
 /**
  * 문단의 제목 수준을 나타내는 열거형 타입입니다.
  */
+@Getter
 public enum Heading {
-	H1, H2, H3, H4, H5, H6
+	H1("#"),
+	H2("##"),
+	H3("###"),
+	H4("####"),
+	H5("#####"),
+	H6("######");
+
+	private String symbol;
+
+	Heading(String symbol) {
+		this.symbol = symbol;
+	}
 }

--- a/src/test/java/goorm/eagle7/stelligence/domain/document/content/DocumentServiceReadTest.java
+++ b/src/test/java/goorm/eagle7/stelligence/domain/document/content/DocumentServiceReadTest.java
@@ -57,6 +57,25 @@ class DocumentServiceReadTest {
 	}
 
 	@Test
+	@DisplayName("문서 조회 - content - 최신버전")
+	void getLatestDocumentContentSuccess() {
+
+		//when
+		String content = documentContentService.getDocument(1L).getContent();
+
+		//then
+		assertThat(content).isEqualTo(
+			"## document1_title2_update\n"
+				+ "document1_content2_update\n"
+				+ "### document1_title3\n"
+				+ "document1_content3\n"
+				+ "# document1_title4_insert\n"
+				+ "document1_content4_insert\n"
+		);
+
+	}
+
+	@Test
 	@DisplayName("문서 조회 - 구버전")
 	void getDocumentByVersionSuccess() {
 

--- a/src/test/java/goorm/eagle7/stelligence/domain/document/content/parser/SectionResponseConcatenatorTest.java
+++ b/src/test/java/goorm/eagle7/stelligence/domain/document/content/parser/SectionResponseConcatenatorTest.java
@@ -1,0 +1,41 @@
+package goorm.eagle7.stelligence.domain.document.content.parser;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import goorm.eagle7.stelligence.domain.document.content.dto.SectionResponse;
+import goorm.eagle7.stelligence.domain.section.model.Heading;
+
+class SectionResponseConcatenatorTest {
+
+	@Test
+	void concat() {
+		List<SectionResponse> sections = new ArrayList<>();
+
+		sections.add(SectionResponse.of(1L, 1L, Heading.H1, "마리모", "마리모는 관상용 식물이다.\n"));
+		sections.add(SectionResponse.of(2L, 1L, Heading.H2, "마리모의 특징", "마리모는 물속에서 자란다.\n\n\n물을 아주 좋아한다.\n"));
+		sections.add(SectionResponse.of(3L, 1L, Heading.H3, "마리모의 사육", "마리모는 물속에서 자란다.\n물을 자주 갈아줘야한다.\n"));
+		sections.add(SectionResponse.of(4L, 1L, Heading.H3, "마리모의 장점", "마리모는 기분이 좋으면 물에 뜬다.\n"));
+
+		String concatContent = SectionResponseConcatenator.concat(sections);
+
+		System.out.println(concatContent);
+
+		Assertions.assertThat(concatContent).isEqualTo(
+			"# 마리모\n"
+				+ "마리모는 관상용 식물이다.\n"
+				+ "## 마리모의 특징\n"
+				+ "마리모는 물속에서 자란다.\n\n\n"
+				+ "물을 아주 좋아한다.\n"
+				+ "### 마리모의 사육\n"
+				+ "마리모는 물속에서 자란다.\n"
+				+ "물을 자주 갈아줘야한다.\n"
+				+ "### 마리모의 장점\n"
+				+ "마리모는 기분이 좋으면 물에 뜬다.\n"
+		);
+	}
+
+}

--- a/src/test/resources/dummy.sql
+++ b/src/test/resources/dummy.sql
@@ -27,22 +27,22 @@ values (1, 'title1', 3, NOW(), NOW()),
 ----------- (10,1) (11,1) (12,1) 은 최초의 4번 문서로 생성된 섹션입니다.
 -- 관련 링크 : https://excited-cycle-902.notion.site/762ff798869f4320aec03bb4fbff27c9?pvs=4
 insert into section (section_id, revision, document_id, heading, title, content, orders, created_at, updated_at)
-values (1, 1, 1, 'H1', 'document1_title1', 'document1_content1', 1, NOW(), NOW()),
+values (1, 1, 1, 'H1', 'document1_title1', 'document1_content1\n', 1, NOW(), NOW()),
        (1, 3, 1, null, null, null, 1, NOW(), NOW()),
-       (2, 1, 1, 'H2', 'document1_title2', 'document1_content2', 2, NOW(), NOW()),
-       (2, 2, 1, 'H2', 'document1_title2_update', 'document1_content2_update', 2, NOW(), NOW()),
-       (3, 1, 1, 'H3', 'document1_title3', 'document1_content3', 3, NOW(), NOW()),
-       (13, 2, 1, 'H1', 'document1_title4_insert', 'document1_content4_insert', 4, NOW(), NOW()),
-       (4, 1, 2, 'H1', 'document2_title1', 'document2_content1', 1, NOW(), NOW()),
-       (5, 1, 2, 'H2', 'document2_title2', 'document2_content2', 3, NOW(), NOW()),
-       (6, 1, 2, 'H3', 'document2_title3', 'document2_content3', 4, NOW(), NOW()),
-       (14, 2, 2, 'H1', 'document2_title4_insert', 'document2_content4_insert', 2, NOW(), NOW()),
-       (7, 1, 3, 'H1', 'document3_title1', 'document3_content1', 1, NOW(), NOW()),
-       (8, 1, 3, 'H2', 'document3_title2', 'document3_content2', 2, NOW(), NOW()),
-       (9, 1, 3, 'H3', 'document3_title3', 'document3_content3', 3, NOW(), NOW()),
-       (10, 1, 4, 'H1', 'document4_title1', 'document4_content1', 1, NOW(), NOW()),
-       (11, 1, 4, 'H2', 'document4_title2', 'document4_content2', 2, NOW(), NOW()),
-       (12, 1, 4, 'H3', 'document4_title3', 'document4_content3', 3, NOW(), NOW());
+       (2, 1, 1, 'H2', 'document1_title2', 'document1_content2\n', 2, NOW(), NOW()),
+       (2, 2, 1, 'H2', 'document1_title2_update', 'document1_content2_update\n', 2, NOW(), NOW()),
+       (3, 1, 1, 'H3', 'document1_title3', 'document1_content3\n', 3, NOW(), NOW()),
+       (13, 2, 1, 'H1', 'document1_title4_insert', 'document1_content4_insert\n', 4, NOW(), NOW()),
+       (4, 1, 2, 'H1', 'document2_title1', 'document2_content1\n', 1, NOW(), NOW()),
+       (5, 1, 2, 'H2', 'document2_title2', 'document2_content2\n', 3, NOW(), NOW()),
+       (6, 1, 2, 'H3', 'document2_title3', 'document2_content3\n', 4, NOW(), NOW()),
+       (14, 2, 2, 'H1', 'document2_title4_insert', 'document2_content4_insert\n', 2, NOW(), NOW()),
+       (7, 1, 3, 'H1', 'document3_title1', 'document3_content1\n', 1, NOW(), NOW()),
+       (8, 1, 3, 'H2', 'document3_title2', 'document3_content2\n', 2, NOW(), NOW()),
+       (9, 1, 3, 'H3', 'document3_title3', 'document3_content3\n', 3, NOW(), NOW()),
+       (10, 1, 4, 'H1', 'document4_title1', 'document4_content1\n', 1, NOW(), NOW()),
+       (11, 1, 4, 'H2', 'document4_title2', 'document4_content2\n', 2, NOW(), NOW()),
+       (12, 1, 4, 'H3', 'document4_title3', 'document4_content3\n', 3, NOW(), NOW());
 
 -- SectionId의 sequence_Id는 15부터
 INSERT into sequence_table (sequence_name, sequence_value)


### PR DESCRIPTION
## 변경 내용 

- 이제는 DocumentResponse에서 전체 문서 내용을 하나의 문자열로 조회할 수 있습니다.
  - DocumentResponse에 content 필드를 추가했습니다.
  - content 필드에 들어가는 내용을 만들 SectionResponseConcatenator를 개발했습니다.
  - 관련 테스트코드를 작성했습니다.

## 특이 사항

- 

## 체크리스트

- [x] PR 날리기 전에 main branch pull 받으셨나요?
- [x] application.properties 등 노출되지 않아야 하는 파일이 올라가지는 않았나요?
- [x] 다른 담당자 파일을 수정한 부분에 대해서 이야기 하셨나요?
- [x] 주석 "상세히" 다셨나요?
- [x] 제출하기 전에 테스트코드 돌려 보셨나요?

closes #60 
