### PR TITLE
64 document section member

### DIFF
--- a/src/main/java/goorm/eagle7/stelligence/domain/document/DocumentController.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/document/DocumentController.java
@@ -9,6 +9,8 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import goorm.eagle7.stelligence.api.ResponseTemplate;
+import goorm.eagle7.stelligence.common.auth.memberinfo.Auth;
+import goorm.eagle7.stelligence.common.auth.memberinfo.MemberInfo;
 import goorm.eagle7.stelligence.domain.document.content.dto.DocumentResponse;
 import goorm.eagle7.stelligence.domain.document.dto.DocumentCreateRequest;
 import io.swagger.v3.oas.annotations.Operation;
@@ -45,9 +47,10 @@ public class DocumentController {
 	)
 	@PostMapping
 	public ResponseTemplate<DocumentResponse> createDocument(
-		@RequestBody DocumentCreateRequest documentCreateRequest
+		@RequestBody DocumentCreateRequest documentCreateRequest,
+		@Auth MemberInfo memberInfo
 	) {
-		return ResponseTemplate.ok(documentService.createDocument(documentCreateRequest));
+		return ResponseTemplate.ok(documentService.createDocument(documentCreateRequest, memberInfo.getId()));
 	}
 
 	@Operation(summary = "문서 내용 조회", description = "문서의 내용을 조회합니다")

--- a/src/main/java/goorm/eagle7/stelligence/domain/document/DocumentService.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/document/DocumentService.java
@@ -35,11 +35,11 @@ public class DocumentService {
 	 * @param documentCreateRequest
 	 * @return
 	 */
-	public DocumentResponse createDocument(DocumentCreateRequest documentCreateRequest) {
+	public DocumentResponse createDocument(DocumentCreateRequest documentCreateRequest, Long loginMemberId) {
 
 		//DocumentContent 저장
 		Document createdDocument = documentContentService.createDocument(documentCreateRequest.getTitle(),
-			documentCreateRequest.getContent());
+			documentCreateRequest.getContent(), loginMemberId);
 
 		//DocumentLink 저장
 		documentGraphService.createDocumentNode(createdDocument);

--- a/src/main/java/goorm/eagle7/stelligence/domain/document/content/DocumentContentService.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/document/content/DocumentContentService.java
@@ -12,6 +12,8 @@ import goorm.eagle7.stelligence.domain.document.content.dto.SectionRequest;
 import goorm.eagle7.stelligence.domain.document.content.dto.SectionResponse;
 import goorm.eagle7.stelligence.domain.document.content.model.Document;
 import goorm.eagle7.stelligence.domain.document.content.parser.DocumentParser;
+import goorm.eagle7.stelligence.domain.member.MemberRepository;
+import goorm.eagle7.stelligence.domain.member.model.Member;
 import goorm.eagle7.stelligence.domain.section.SectionRepository;
 import goorm.eagle7.stelligence.domain.section.model.Heading;
 import goorm.eagle7.stelligence.domain.section.model.Section;
@@ -36,6 +38,7 @@ public class DocumentContentService {
 	private final SectionRepository sectionRepository;
 	private final SectionIdGenerator sectionIdGenerator;
 	private final DocumentParser documentParser;
+	private final MemberRepository memberRepository;
 
 	/**
 	 * Document를 생성합니다.
@@ -43,10 +46,15 @@ public class DocumentContentService {
 	 * @param rawContent 사용자가 작성한 글 내용
 	 */
 	@Transactional
-	public Document createDocument(String title, String rawContent) {
+	public Document createDocument(String title, String rawContent, Long loginMemberId) {
 		log.trace("DocumentService.createDocument called");
+
+		//사용자 조회
+		Member author = memberRepository.findById(loginMemberId)
+			.orElseThrow(() -> new BaseException("존재하지 않는 사용자입니다. 사용자 ID : " + loginMemberId));
+
 		//document 생성
-		Document document = Document.createDocument(title);
+		Document document = Document.createDocument(title, author);
 		documentRepository.save(document);
 
 		List<SectionRequest> sectionRequests = documentParser.parse(rawContent);

--- a/src/main/java/goorm/eagle7/stelligence/domain/document/content/DocumentContentService.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/document/content/DocumentContentService.java
@@ -12,7 +12,6 @@ import goorm.eagle7.stelligence.domain.document.content.dto.SectionRequest;
 import goorm.eagle7.stelligence.domain.document.content.dto.SectionResponse;
 import goorm.eagle7.stelligence.domain.document.content.model.Document;
 import goorm.eagle7.stelligence.domain.document.content.parser.DocumentParser;
-import goorm.eagle7.stelligence.domain.member.MemberRepository;
 import goorm.eagle7.stelligence.domain.member.model.Member;
 import goorm.eagle7.stelligence.domain.section.SectionRepository;
 import goorm.eagle7.stelligence.domain.section.model.Heading;
@@ -38,20 +37,17 @@ public class DocumentContentService {
 	private final SectionRepository sectionRepository;
 	private final SectionIdGenerator sectionIdGenerator;
 	private final DocumentParser documentParser;
-	private final MemberRepository memberRepository;
 
 	/**
 	 * Document를 생성합니다.
+	 * DocumentService 내에서만 호출되어야 합니다.
+	 * 외부에서 호출시 DocumentGraph와 Content 간 일관성이 깨지는 문제가 발생될 수 있습니다.
 	 * @param title 문서의 제목
 	 * @param rawContent 사용자가 작성한 글 내용
 	 */
 	@Transactional
-	public Document createDocument(String title, String rawContent, Long loginMemberId) {
+	public Document createDocument(String title, String rawContent, Member author) {
 		log.trace("DocumentService.createDocument called");
-
-		//사용자 조회
-		Member author = memberRepository.findById(loginMemberId)
-			.orElseThrow(() -> new BaseException("존재하지 않는 사용자입니다. 사용자 ID : " + loginMemberId));
 
 		//document 생성
 		Document document = Document.createDocument(title, author);

--- a/src/main/java/goorm/eagle7/stelligence/domain/document/content/model/Document.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/document/content/model/Document.java
@@ -1,18 +1,22 @@
 package goorm.eagle7.stelligence.domain.document.content.model;
 
 import static jakarta.persistence.GenerationType.*;
-import static lombok.AccessLevel.*;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import goorm.eagle7.stelligence.common.entity.BaseTimeEntity;
+import goorm.eagle7.stelligence.domain.member.model.Member;
 import goorm.eagle7.stelligence.domain.section.model.Section;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -20,12 +24,10 @@ import lombok.NoArgsConstructor;
  * Document Entity
  * 문서를 저장하기 위한 엔티티 클래스입니다.
  * 문서는 여러 Section을 가질 수 있습니다.
- *
- * todo: 추후 작성자를 저장할 수 있어야 합니다.
  */
 @Entity
 @Getter
-@NoArgsConstructor(access = PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Document extends BaseTimeEntity {
 
 	@Id
@@ -33,7 +35,12 @@ public class Document extends BaseTimeEntity {
 	@Column(name = "document_id")
 	private Long id;
 
-	//Member (creator)
+	/**
+	 * 문서를 최초 생성한 사용자입니다.
+	 */
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "author_id")
+	private Member author;
 
 	private String title;
 
@@ -49,12 +56,11 @@ public class Document extends BaseTimeEntity {
 	private List<Section> sections = new ArrayList<>();
 
 	//===생성===//
-	public static Document createDocument(String title) {
+	public static Document createDocument(String title, Member author) {
 		Document document = new Document();
 		document.title = title;
-
-		//최초 생성 시 버전은 1입니다.
-		document.currentRevision = 1L;
+		document.author = author;
+		document.currentRevision = 1L; //최초 생성 시 버전은 1입니다.
 		return document;
 	}
 

--- a/src/main/java/goorm/eagle7/stelligence/domain/document/dto/DocumentCreateRequest.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/document/dto/DocumentCreateRequest.java
@@ -1,9 +1,11 @@
 package goorm.eagle7.stelligence.domain.document.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
 @Schema(description = "생성할 문서의 정보")
 public class DocumentCreateRequest {
 

--- a/src/main/java/goorm/eagle7/stelligence/domain/member/model/Member.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/member/model/Member.java
@@ -103,4 +103,8 @@ public class Member extends BaseTimeEntity {
 	public void updateRefreshToken(String refreshToken) {
 		this.refreshToken = refreshToken;
 	}
+
+	public void incrementContributes() {
+		this.contributes++;
+	}
 }

--- a/src/test/java/goorm/eagle7/stelligence/config/mockdata/TestFixtureGenerator.java
+++ b/src/test/java/goorm/eagle7/stelligence/config/mockdata/TestFixtureGenerator.java
@@ -17,8 +17,8 @@ public class TestFixtureGenerator {
 		return Member.of("name", nickname, "email", "imageUrl", "socialId");
 	}
 
-	public static Document document(String title) {
-		return Document.createDocument(title);
+	public static Document document(String title, Member author) {
+		return Document.createDocument(title, author);
 	}
 
 	public static Section section(Document document, Long id, Long revision, String title, int order) {

--- a/src/test/java/goorm/eagle7/stelligence/domain/document/DocumentServiceTest.java
+++ b/src/test/java/goorm/eagle7/stelligence/domain/document/DocumentServiceTest.java
@@ -56,9 +56,9 @@ class DocumentServiceTest {
 			1
 		);
 
-		DocumentCreateRequest documentCreateRequest = new DocumentCreateRequest(
+		DocumentCreateRequest documentCreateRequest = DocumentCreateRequest.of(
 			"testTitle",
-			1L,
+			null,
 			"testSectionContent"
 		);
 

--- a/src/test/java/goorm/eagle7/stelligence/domain/document/DocumentServiceTest.java
+++ b/src/test/java/goorm/eagle7/stelligence/domain/document/DocumentServiceTest.java
@@ -1,0 +1,90 @@
+package goorm.eagle7.stelligence.domain.document;
+
+import static goorm.eagle7.stelligence.config.mockdata.TestFixtureGenerator.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import goorm.eagle7.stelligence.domain.document.content.DocumentContentService;
+import goorm.eagle7.stelligence.domain.document.content.dto.DocumentResponse;
+import goorm.eagle7.stelligence.domain.document.content.model.Document;
+import goorm.eagle7.stelligence.domain.document.dto.DocumentCreateRequest;
+import goorm.eagle7.stelligence.domain.document.graph.DocumentGraphService;
+import goorm.eagle7.stelligence.domain.member.MemberRepository;
+import goorm.eagle7.stelligence.domain.member.model.Member;
+import goorm.eagle7.stelligence.domain.section.model.Heading;
+import goorm.eagle7.stelligence.domain.section.model.Section;
+
+@ExtendWith(MockitoExtension.class)
+class DocumentServiceTest {
+
+	@Mock
+	private MemberRepository memberRepository;
+
+	@Mock
+	private DocumentContentService documentContentService;
+
+	@Mock
+	private DocumentGraphService documentGraphService;
+
+	@InjectMocks
+	private DocumentService documentService;
+
+	@Test
+	void createDocument() {
+		//given
+		Long loginMemberId = 1L;
+
+		Member author = member("testNickname");
+
+		Document document = document("testTitle", author);
+
+		Section.createSection(
+			document,
+			1L,
+			1L,
+			Heading.H1,
+			"testTitle",
+			"testSectionContent",
+			1
+		);
+
+		DocumentCreateRequest documentCreateRequest = new DocumentCreateRequest(
+			"testTitle",
+			1L,
+			"testSectionContent"
+		);
+
+		when(memberRepository.findById(loginMemberId)).thenReturn(Optional.of(author));
+		when(documentContentService.createDocument("testTitle", "testSectionContent", author))
+			.thenReturn(document);
+
+		//when
+		DocumentResponse documentResponse = documentService.createDocument(
+			documentCreateRequest,
+			loginMemberId
+		);
+
+		//then
+		//memberRepository, documentContentService, documentGraphService가 각각 한 번씩 호출되어야 합니다.
+		verify(memberRepository, times(1)).findById(loginMemberId);
+		verify(documentContentService, times(1)).createDocument("testTitle", "testSectionContent", author);
+		verify(documentGraphService, times(1)).createDocumentNode(document);
+
+		//기여한 글 개수가 올라야 합니다.
+		assertThat(author.getContributes()).isEqualTo(1);
+
+		//DocumentResponse가 정상적으로 생성되어야 합니다.
+		assertThat(documentResponse.getTitle()).isEqualTo("testTitle");
+		assertThat(documentResponse.getSections()).hasSize(1);
+		assertThat(documentResponse.getSections().get(0).getTitle()).isEqualTo("testTitle");
+		assertThat(documentResponse.getSections().get(0).getContent()).isEqualTo("testSectionContent");
+	}
+}

--- a/src/test/java/goorm/eagle7/stelligence/domain/document/content/DocumentMergeConcurrencyTest.java
+++ b/src/test/java/goorm/eagle7/stelligence/domain/document/content/DocumentMergeConcurrencyTest.java
@@ -64,7 +64,7 @@ class DocumentMergeConcurrencyTest {
 				+ "### title3\n"
 				+ "content3";
 
-		Document document = documentContentService.createDocument(title, rawContent, 1L);
+		Document document = documentContentService.createDocument(title, rawContent, member("nickname"));
 
 		//트랜잭션 종료를 통해 이후 쓰레드들이 정상적으로 동작할 수 있게 함
 		//em.flush(), em.clear() 사용시, 쓰레드들이 정상적으로 동작하지 않음

--- a/src/test/java/goorm/eagle7/stelligence/domain/document/content/DocumentMergeConcurrencyTest.java
+++ b/src/test/java/goorm/eagle7/stelligence/domain/document/content/DocumentMergeConcurrencyTest.java
@@ -1,10 +1,12 @@
 package goorm.eagle7.stelligence.domain.document.content;
 
+import static goorm.eagle7.stelligence.config.mockdata.TestFixtureGenerator.*;
 import static org.assertj.core.api.Assertions.*;
 
 import java.util.List;
 
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,6 +19,8 @@ import goorm.eagle7.stelligence.config.TestConfig;
 import goorm.eagle7.stelligence.domain.document.content.model.Document;
 import goorm.eagle7.stelligence.domain.section.SectionRepository;
 import goorm.eagle7.stelligence.domain.section.model.Heading;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 
 @SpringBootTest
 @Transactional
@@ -31,6 +35,14 @@ class DocumentMergeConcurrencyTest {
 
 	@Autowired
 	private SectionRepository sectionRepository;
+
+	@PersistenceContext
+	private EntityManager em;
+
+	@BeforeEach
+	void setUp() {
+		em.persist(member("nickname"));
+	}
 
 	@AfterEach
 	void tearDown() {
@@ -52,7 +64,7 @@ class DocumentMergeConcurrencyTest {
 				+ "### title3\n"
 				+ "content3";
 
-		Document document = documentContentService.createDocument(title, rawContent);
+		Document document = documentContentService.createDocument(title, rawContent, 1L);
 
 		//트랜잭션 종료를 통해 이후 쓰레드들이 정상적으로 동작할 수 있게 함
 		//em.flush(), em.clear() 사용시, 쓰레드들이 정상적으로 동작하지 않음
@@ -88,7 +100,7 @@ class DocumentMergeConcurrencyTest {
 		TestTransaction.start(); // 지연로딩을 위한 트랜잭션 재시작
 
 		Document findDocument = documentContentRepository.findById(document.getId()).get();
-		   
+
 		// 동시성 문제 발생시 2가 나옴
 		//DocumentRepository.findForUpdate의 @Lock을 없애보면 확인 가능
 		assertThat(findDocument.getCurrentRevision()).isEqualTo(3L);

--- a/src/test/java/goorm/eagle7/stelligence/domain/document/content/DocumentMergeConcurrencyTest.java
+++ b/src/test/java/goorm/eagle7/stelligence/domain/document/content/DocumentMergeConcurrencyTest.java
@@ -17,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import goorm.eagle7.stelligence.config.TestConfig;
 import goorm.eagle7.stelligence.domain.document.content.model.Document;
+import goorm.eagle7.stelligence.domain.member.model.Member;
 import goorm.eagle7.stelligence.domain.section.SectionRepository;
 import goorm.eagle7.stelligence.domain.section.model.Heading;
 import jakarta.persistence.EntityManager;
@@ -53,6 +54,8 @@ class DocumentMergeConcurrencyTest {
 	@DisplayName("Merge 동시성 테스트")
 	void mergeConcurrency() {
 
+		Member author = em.find(Member.class, 1L);
+
 		String title = "title";
 
 		String rawContent =
@@ -64,7 +67,7 @@ class DocumentMergeConcurrencyTest {
 				+ "### title3\n"
 				+ "content3";
 
-		Document document = documentContentService.createDocument(title, rawContent, member("nickname"));
+		Document document = documentContentService.createDocument(title, rawContent, author);
 
 		//트랜잭션 종료를 통해 이후 쓰레드들이 정상적으로 동작할 수 있게 함
 		//em.flush(), em.clear() 사용시, 쓰레드들이 정상적으로 동작하지 않음

--- a/src/test/java/goorm/eagle7/stelligence/domain/document/content/DocumentServiceCreateTest.java
+++ b/src/test/java/goorm/eagle7/stelligence/domain/document/content/DocumentServiceCreateTest.java
@@ -1,7 +1,9 @@
 package goorm.eagle7.stelligence.domain.document.content;
 
+import static goorm.eagle7.stelligence.config.mockdata.TestFixtureGenerator.*;
 import static org.assertj.core.api.Assertions.*;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,6 +30,11 @@ class DocumentServiceCreateTest {
 	@PersistenceContext
 	private EntityManager em;
 
+	@BeforeEach
+	void setUp() {
+		em.persist(member("nickname"));
+	}
+
 	@Test
 	@DisplayName("문서 생성 - 성공")
 	void createDocumentSuccess() {
@@ -42,7 +49,7 @@ class DocumentServiceCreateTest {
 				+ "### title3\n"
 				+ "content3";
 
-		Document document = documentContentService.createDocument(title, rawContent);
+		Document document = documentContentService.createDocument(title, rawContent, 1L);
 
 		em.flush();
 		em.clear();

--- a/src/test/java/goorm/eagle7/stelligence/domain/document/content/DocumentServiceCreateTest.java
+++ b/src/test/java/goorm/eagle7/stelligence/domain/document/content/DocumentServiceCreateTest.java
@@ -49,7 +49,7 @@ class DocumentServiceCreateTest {
 				+ "### title3\n"
 				+ "content3";
 
-		Document document = documentContentService.createDocument(title, rawContent, 1L);
+		Document document = documentContentService.createDocument(title, rawContent, member("nickname"));
 
 		em.flush();
 		em.clear();

--- a/src/test/java/goorm/eagle7/stelligence/domain/document/content/DocumentServiceCreateTest.java
+++ b/src/test/java/goorm/eagle7/stelligence/domain/document/content/DocumentServiceCreateTest.java
@@ -13,6 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import goorm.eagle7.stelligence.config.TestConfig;
 import goorm.eagle7.stelligence.domain.document.content.model.Document;
+import goorm.eagle7.stelligence.domain.member.model.Member;
 import goorm.eagle7.stelligence.domain.section.model.Heading;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
@@ -38,6 +39,7 @@ class DocumentServiceCreateTest {
 	@Test
 	@DisplayName("문서 생성 - 성공")
 	void createDocumentSuccess() {
+		Member author = em.find(Member.class, 1L);
 
 		String title = "title";
 		String rawContent =
@@ -49,7 +51,7 @@ class DocumentServiceCreateTest {
 				+ "### title3\n"
 				+ "content3";
 
-		Document document = documentContentService.createDocument(title, rawContent, member("nickname"));
+		Document document = documentContentService.createDocument(title, rawContent, author);
 
 		em.flush();
 		em.clear();

--- a/src/test/java/goorm/eagle7/stelligence/domain/document/graph/DocumentFacadeServiceGraphTest.java
+++ b/src/test/java/goorm/eagle7/stelligence/domain/document/graph/DocumentFacadeServiceGraphTest.java
@@ -41,7 +41,7 @@ class DocumentFacadeServiceGraphTest {
 				+ "content3";
 
 		DocumentCreateRequest documentCreateRequest = DocumentCreateRequest.of(title, null, rawContent);
-		DocumentResponse documentResponse = documentService.createDocument(documentCreateRequest);
+		DocumentResponse documentResponse = documentService.createDocument(documentCreateRequest, 1L);
 
 		DocumentNode documentNode = documentNodeRepository.findById(documentResponse.getDocumentId()).get();
 
@@ -66,12 +66,12 @@ class DocumentFacadeServiceGraphTest {
 				+ "content3";
 
 		DocumentCreateRequest documentCreateRequest1 = DocumentCreateRequest.of(parentTitle, null, rawContent);
-		DocumentResponse documentResponse = documentService.createDocument(documentCreateRequest1);
+		DocumentResponse documentResponse = documentService.createDocument(documentCreateRequest1, 1L);
 		Long parentNodeId = documentResponse.getDocumentId();
 
 		//when
 		DocumentCreateRequest documentCreateRequest2 = DocumentCreateRequest.of(childTitle, parentNodeId, rawContent);
-		DocumentResponse documentResponse2 = documentService.createDocument(documentCreateRequest2);
+		DocumentResponse documentResponse2 = documentService.createDocument(documentCreateRequest2, 1L);
 
 		//then
 		DocumentNode childDocumentNode = documentNodeRepository.findById(documentResponse2.getDocumentId()).get();

--- a/src/test/java/goorm/eagle7/stelligence/domain/document/graph/DocumentGraphServiceTest.java
+++ b/src/test/java/goorm/eagle7/stelligence/domain/document/graph/DocumentGraphServiceTest.java
@@ -1,5 +1,6 @@
 package goorm.eagle7.stelligence.domain.document.graph;
 
+import static goorm.eagle7.stelligence.config.mockdata.TestFixtureGenerator.*;
 import static org.assertj.core.api.Assertions.*;
 
 import java.util.List;
@@ -39,7 +40,7 @@ class DocumentGraphServiceTest {
 	@DisplayName("최상위 문서 노드 생성 서비스 테스트")
 	void createDocumentNode() {
 
-		Document createdDocument = Document.createDocument("제목1");
+		Document createdDocument = Document.createDocument("제목1", member("Paul"));
 		documentContentRepository.save(createdDocument);
 
 		documentGraphService.createDocumentNode(createdDocument);
@@ -58,12 +59,12 @@ class DocumentGraphServiceTest {
 	void createDocumentNodeWithParent() {
 
 		// 기존에 존재하는 상위 문서
-		Document parentDocument = Document.createDocument("상위 문서 제목");
+		Document parentDocument = Document.createDocument("상위 문서 제목", member("Paul"));
 		documentContentRepository.save(parentDocument);
 		documentGraphService.createDocumentNode(parentDocument);
 
 		// 하위 문서 생성
-		Document createdDocument = Document.createDocument("하위 문서 제목");
+		Document createdDocument = Document.createDocument("하위 문서 제목", member("Paul"));
 		documentContentRepository.save(createdDocument);
 		documentGraphService.createDocumentNodeWithParent(createdDocument, parentDocument.getId());
 


### PR DESCRIPTION
## 변경 내용 

- 이제는 Document 생성시 Member를 함께 저장합니다.
- Document 조회시 최초 작성자 정보를 제공하는 기능은 이후의 이슈에서 처리할 예정입니다.
- Document의 정적팩토리 메서드가 멤버를 받도록 하고, Controller로부터 loginId를 받아야 했기 때문에 굉장히 많은 클래스가 수정되었습니다.

## 특이 사항

- 많은 클래스가 수정되었기 때문에 빠르게 로컬에 붙이고 개발 이어가시면 좋을 것 같습니다.
- 영민님 테스트 코드를 수정한 부분이 있습니다. (service의 파라미터 변경 - loginId 추가)
- 한나님 Member Entity를 수정한 부분이 있습니다. (incrementContributes 메서드 작성)

## 체크리스트

- [x] PR 날리기 전에 main branch pull 받으셨나요?
- [x] application.properties 등 노출되지 않아야 하는 파일이 올라가지는 않았나요?
- [x] 다른 담당자 파일을 수정한 부분에 대해서 이야기 하셨나요?
- [x] 주석 "상세히" 다셨나요?
- [x] 제출하기 전에 테스트코드 돌려 보셨나요?

closes #64 
