### PR TITLE
81 SectionRepository.findLatestSection이 Optional을 반환

### DIFF
--- a/src/main/java/goorm/eagle7/stelligence/domain/amendment/AmendmentService.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/amendment/AmendmentService.java
@@ -3,6 +3,7 @@ package goorm.eagle7.stelligence.domain.amendment;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import goorm.eagle7.stelligence.api.exception.BaseException;
 import goorm.eagle7.stelligence.domain.amendment.dto.AmendmentRequest;
 import goorm.eagle7.stelligence.domain.amendment.model.Amendment;
 import goorm.eagle7.stelligence.domain.section.SectionRepository;
@@ -34,7 +35,8 @@ public class AmendmentService {
 	 * 수정안 생성(새로운 문단 생성)
 	 */
 	private Amendment createAmendment(AmendmentRequest amendmentRequest) {
-		Section section = sectionRepository.findLatestSection(amendmentRequest.getSectionId());
+		Section section = sectionRepository.findLatestSection(amendmentRequest.getSectionId())
+			.orElseThrow(() -> new BaseException("존재하지 않는 섹션입니다. 섹션 ID : " + amendmentRequest.getSectionId()));
 
 		return Amendment.forCreate(
 			section,
@@ -49,7 +51,8 @@ public class AmendmentService {
 	 * 수정안 생성(기존 문단 수정)
 	 */
 	private Amendment updateAmendment(AmendmentRequest amendmentRequest) {
-		Section section = sectionRepository.findLatestSection(amendmentRequest.getSectionId());
+		Section section = sectionRepository.findLatestSection(amendmentRequest.getSectionId())
+			.orElseThrow(() -> new BaseException("존재하지 않는 섹션입니다. 섹션 ID : " + amendmentRequest.getSectionId()));
 
 		return Amendment.forUpdate(
 			section,
@@ -63,7 +66,8 @@ public class AmendmentService {
 	 * 수정안 생성(기존 문단 삭제)
 	 */
 	private Amendment deleteAmendment(AmendmentRequest amendmentRequest) {
-		Section section = sectionRepository.findLatestSection(amendmentRequest.getSectionId());
+		Section section = sectionRepository.findLatestSection(amendmentRequest.getSectionId())
+			.orElseThrow(() -> new BaseException("존재하지 않는 섹션입니다. 섹션 ID : " + amendmentRequest.getSectionId()));
 
 		return Amendment.forDelete(section);
 	}

--- a/src/main/java/goorm/eagle7/stelligence/domain/section/SectionRepository.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/section/SectionRepository.java
@@ -1,6 +1,7 @@
 package goorm.eagle7.stelligence.domain.section;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -32,12 +33,12 @@ public interface SectionRepository extends JpaRepository<Section, SectionId> {
 	/**
 	 * 특정 SectionId에 대해 가장 최근에 개정된 버전을 가져옵니다.
 	 * @param sectionId
-	 * @return
+	 * @return 최근 개정된 Section
 	 */
 	@Query("select s from Section s " +
 		"where s.id = :sectionId " +
 		"order by s.revision desc limit 1")
-	Section findLatestSection(Long sectionId);
+	Optional<Section> findLatestSection(Long sectionId);
 
 	/**
 	 * Section이 중간에 삽입되는 경우

--- a/src/test/java/goorm/eagle7/stelligence/domain/section/SectionRepositoryTest.java
+++ b/src/test/java/goorm/eagle7/stelligence/domain/section/SectionRepositoryTest.java
@@ -2,6 +2,8 @@ package goorm.eagle7.stelligence.domain.section;
 
 import static org.assertj.core.api.Assertions.*;
 
+import java.util.Optional;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,7 +22,8 @@ class SectionRepositoryTest {
 	@Test
 	@DisplayName("최신 섹션 조회 - 성공")
 	void findLatestSectionSuccess() {
-		Section latestSection = sectionRepository.findLatestSection(1L);
+		Section latestSection = sectionRepository.findLatestSection(1L)
+			.orElseThrow(() -> new RuntimeException("존재하지 않는 섹션입니다."));
 
 		assertThat(latestSection.getId()).isEqualTo(1L);
 		assertThat(latestSection.getRevision()).isEqualTo(3L);
@@ -29,8 +32,8 @@ class SectionRepositoryTest {
 	@Test
 	@DisplayName("최신 섹션 조회 - 실패")
 	void findLatestSectionFail() {
-		Section latestSection = sectionRepository.findLatestSection(9999999L);
+		Optional<Section> latestSection = sectionRepository.findLatestSection(9999999L);
 
-		assertThat(latestSection).isNull();
+		assertThat(latestSection).isEmpty();
 	}
 }


### PR DESCRIPTION
## 변경 내용 

- 이제는 SectionRepository.findLatestSection이 Optional을 반환합니다.

## 특이 사항

- AmendmentService에서 findLatestSection을 사용하는 부분을 수정했습니다. @eenzzi  확인해주세용

## 체크리스트

- [x] PR 날리기 전에 main branch pull 받으셨나요?
- [x] application.properties 등 노출되지 않아야 하는 파일이 올라가지는 않았나요?
- [x] 다른 담당자 파일을 수정한 부분에 대해서 이야기 하셨나요?
- [x] 주석 "상세히" 다셨나요?
- [x] 제출하기 전에 테스트코드 돌려 보셨나요?

closes #81 
