### PR TITLE
bug: MemberInfo가 Swagger에 RequestBody로 나타나는 문제 해결

### DIFF
--- a/src/main/java/goorm/eagle7/stelligence/common/auth/memberinfo/MemberInfo.java
+++ b/src/main/java/goorm/eagle7/stelligence/common/auth/memberinfo/MemberInfo.java
@@ -1,6 +1,7 @@
 package goorm.eagle7.stelligence.common.auth.memberinfo;
 
 import goorm.eagle7.stelligence.domain.member.model.Role;
+import io.swagger.v3.oas.annotations.Hidden;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -9,6 +10,7 @@ import lombok.NoArgsConstructor;
 /**
  * MemberInfoArgumentResolver를 이용해 @Auth 애노테이션 사용 시 반환하는 객체
  */
+@Hidden // Swagger 문서에 노출되지 않도록 설정
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(staticName = "of")


### PR DESCRIPTION
## 변경 내용 

- Swagger의 글 생성 API의 RequestBody에 MemberInfo가 요청값으로 나타나는 문제를 해결했습니다.

## 특이 사항

- @Sooamazing 코드 수정했으니 확인해주세요.

## 체크리스트

- [x] PR 날리기 전에 main branch pull 받으셨나요?
- [x] application.properties 등 노출되지 않아야 하는 파일이 올라가지는 않았나요?
- [x] 다른 담당자 파일을 수정한 부분에 대해서 이야기 하셨나요?
- [x] 주석 "상세히" 다셨나요?
- [x] 제출하기 전에 테스트코드 돌려 보셨나요?

closes #83 
