### PR TITLE
78 문서 그래프 캐시 적용

### DIFF
--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -41,6 +41,7 @@ services:
   redis:
     image: redis:latest
     container_name: redis
+    command: redis-server --maxmemory 500mb --maxmemory-policy volatile-lru
     restart: unless-stopped
     ports:
       - 6379:6379

--- a/src/main/java/goorm/eagle7/stelligence/domain/document/graph/DocumentGraphService.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/document/graph/DocumentGraphService.java
@@ -29,6 +29,7 @@ public class DocumentGraphService {
 	 * 생성된 Document 객체를 기준으로 새로운 문서 노드를 생성합니다.
 	 * 상위 문서가 없는 최상위 문서에 대한 노드를 생성할 때민 사용합니다.
 	 * 상위 문서가 존재하는 문서 노드는 {@link #createDocumentNodeWithParent} 메서드를 통해 생성해주세요.
+	 * (기존에 설정된 그래프 관련 캐시를 모두 무효화합니다.)
 	 * @param document: 생성된 문서를 나타냅니다.
 	 */
 	@Transactional
@@ -42,6 +43,7 @@ public class DocumentGraphService {
 	/**
 	 * 생성된 Document 객체를 기준으로 새로운 문서 노드를 생성합니다.
 	 * 추가로, parentDocumentId를 갖는 문서 노드와 생성된 문서 노드 간의 링크를 연결합니다.
+	 * (기존에 설정된 그래프 관련 캐시를 모두 무효화합니다.)
 	 * @param document: 생성된 문서를 나타냅니다.
 	 * @param parentDocumentId: 링크를 연결할 상위 문서의 id를 나타냅니다.
 	 */
@@ -72,6 +74,7 @@ public class DocumentGraphService {
 	/**
 	 * 모든 문서와 문서 간의 관계를 조회합니다.
 	 * 문서가 많아지면 부하가 발생할 수 있습니다.
+	 * (비슷한 요청이 반복될 것으로 예상되어 데이터를 캐싱합니다.)
 	 * @return DocumentGraphResponse: 문서 그래프와 관련된 응답 DTO입니다.
 	 */
 	@Cacheable(value = "RootGraph", cacheManager = "cacheManager")
@@ -106,6 +109,7 @@ public class DocumentGraphService {
 
 	/**
 	 * 처음 그래프를 조회할 때에는 루트 노드로부터 특정 깊이까지를 조회할 수 있어야합니다.
+	 * (비슷한 요청이 반복될 것으로 예상되어 데이터를 캐싱합니다.)
 	 * @param depth: 루트 노드로부터 몇 번째 깊이까지를 조회할 것인지를 결정합니다.
 	 * @return DocumentGraphResponse: 문서 그래프와 관련된 응답 DTO입니다.
 	 */
@@ -121,6 +125,7 @@ public class DocumentGraphService {
 	/**
 	 * 문서 ID에 따라 특정 문서 노드를 삭제합니다.
 	 * 이때, 해당 문서의 하위 문서의 링크와 그룹을 함께 재정의합니다.
+	 * (기존에 설정된 그래프 관련 캐시를 모두 무효화합니다.)
 	 * @param documentId: 삭제할 문서의 ID입니다.
 	 */
 	@Transactional
@@ -141,6 +146,7 @@ public class DocumentGraphService {
 	 * documentId에 따라 특정 문서를 찾습니다.
 	 * 찾은 특정 문서의 상위 문서를 parentDocumentId를 갖는 문서로 변경합니다.
 	 * parentDocumentId가 null이라면 링크를 삭제합니다.
+	 * (기존에 설정된 그래프 관련 캐시를 모두 무효화합니다.)
 	 * @param documentId: 링크를 변경할 문서 ID
 	 * @param parentDocumentId: 링크를 연결할 문서 ID
 	 */

--- a/src/main/java/goorm/eagle7/stelligence/domain/document/graph/DocumentGraphService.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/document/graph/DocumentGraphService.java
@@ -3,6 +3,8 @@ package goorm.eagle7.stelligence.domain.document.graph;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -30,6 +32,7 @@ public class DocumentGraphService {
 	 * @param document: 생성된 문서를 나타냅니다.
 	 */
 	@Transactional
+	@CacheEvict(value="RootGraph", allEntries = true, cacheManager = "cacheManager")
 	public void createDocumentNode(Document document) {
 
 		DocumentNode documentNode = new DocumentNode(document.getId(), document.getTitle());
@@ -43,6 +46,7 @@ public class DocumentGraphService {
 	 * @param parentDocumentId: 링크를 연결할 상위 문서의 id를 나타냅니다.
 	 */
 	@Transactional
+	@CacheEvict(value="RootGraph", allEntries = true, cacheManager = "cacheManager")
 	public void createDocumentNodeWithParent(Document document, Long parentDocumentId) {
 
 		DocumentNode parentDocumentNode = documentNodeRepository.findSingleNodeByDocumentId(parentDocumentId)
@@ -70,6 +74,7 @@ public class DocumentGraphService {
 	 * 문서가 많아지면 부하가 발생할 수 있습니다.
 	 * @return DocumentGraphResponse: 문서 그래프와 관련된 응답 DTO입니다.
 	 */
+	@Cacheable(value = "RootGraph", cacheManager = "cacheManager")
 	public DocumentGraphResponse findAllGraph() {
 
 		List<DocumentNodeResponse> documentNodes = documentNodeRepository.findAllDocumentNode();
@@ -104,6 +109,7 @@ public class DocumentGraphService {
 	 * @param depth: 루트 노드로부터 몇 번째 깊이까지를 조회할 것인지를 결정합니다.
 	 * @return DocumentGraphResponse: 문서 그래프와 관련된 응답 DTO입니다.
 	 */
+	@Cacheable(value = "RootGraph", key = "#depth", cacheManager = "cacheManager")
 	public DocumentGraphResponse findFromRootNodesWithDepth(int depth) {
 
 		List<DocumentNodeResponse> documentNodes = documentNodeRepository.findDocumentNodeFromRootWithDepth(depth);
@@ -118,6 +124,7 @@ public class DocumentGraphService {
 	 * @param documentId: 삭제할 문서의 ID입니다.
 	 */
 	@Transactional
+	@CacheEvict(value="RootGraph", allEntries = true, cacheManager = "cacheManager")
 	public void deleteDocumentNode(Long documentId) {
 
 		boolean isRoot = documentNodeRepository.isRootNode(documentId)
@@ -138,6 +145,7 @@ public class DocumentGraphService {
 	 * @param parentDocumentId: 링크를 연결할 문서 ID
 	 */
 	@Transactional
+	@CacheEvict(value="RootGraph", allEntries = true, cacheManager = "cacheManager")
 	public void updateDocumentLink(Long documentId, Long parentDocumentId) {
 		if (parentDocumentId != null) {
 			changeLinkToParent(documentId, parentDocumentId);


### PR DESCRIPTION
## 변경 내용 

- 문서 그래프를 조회할 때 캐싱을 적용하였습니다.
    - 자주 조회되지 않을 데이터를 캐싱하는 것은 비효율적입니다.
    - 루트 노드로부터 조회 or 전체 조회할 때만 캐싱을 적용하였습니다.

## 특이 사항

- docker-compose-local.yml에 redis의 maxmemory를 500mb로 제한하는 코드를 추가하였습니다. (1gb 등 설정 변경 가능)
- docker-compose-local.yml에 redis의 희생자 선정 알고리즘을 volatile-lru로 설정하였습니다. (volatile-lfu 등 설정 변경 가능)
    - volatile-lru: expire가 설정된 캐시들 중, 가장 오래전에 조회된 캐시를 희생시킵니다.
- docker-compose -f docker-compose-local.yml up --build -d 로 다시 빌드해주세요

## 체크리스트

- [x] PR 날리기 전에 main branch pull 받으셨나요?
- [x] application.properties 등 노출되지 않아야 하는 파일이 올라가지는 않았나요?
- [x] 다른 담당자 파일을 수정한 부분에 대해서 이야기 하셨나요?
- [x] 주석 "상세히" 다셨나요?
- [x] 제출하기 전에 테스트코드 돌려 보셨나요?

closes #
