### PR TITLE
88 RequestCachingFilter 로직 변경 

### DIFF
--- a/src/main/java/goorm/eagle7/stelligence/api/log/RequestLoggingFilter.java
+++ b/src/main/java/goorm/eagle7/stelligence/api/log/RequestLoggingFilter.java
@@ -24,8 +24,8 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Order(value = Ordered.HIGHEST_PRECEDENCE)
 @Component
-@WebFilter(filterName = "RequestCachingFilter", urlPatterns = "/*") // 애플리케이션의 모든 요청에 대해 매핑됨
-public class RequestCachingFilter extends OncePerRequestFilter {
+@WebFilter(filterName = "RequestLoggingFilter", urlPatterns = "/*") // 애플리케이션의 모든 요청에 대해 매핑됨
+public class RequestLoggingFilter extends OncePerRequestFilter {
 
 	// 로깅 제외 URL 패턴
 	private static final String[] EXCLUDE_URL_PATTERN = {"/swagger-ui/", "/api-docs", "/v3/api-docs"};

--- a/src/main/java/goorm/eagle7/stelligence/api/log/RequestLoggingFilter.java
+++ b/src/main/java/goorm/eagle7/stelligence/api/log/RequestLoggingFilter.java
@@ -29,7 +29,7 @@ public class RequestLoggingFilter extends OncePerRequestFilter {
 
 	// 로깅 제외 URL 패턴
 	private static final String[] EXCLUDE_URL_PATTERN = {"/swagger-ui/", "/api-docs", "/v3/api-docs"};
-	private static final int MAX_BODY_PRINT_LENGTH = 100;
+	private static final int MAX_BODY_PRINT_LENGTH = 100; // body 출력 길이 제한
 
 	@Override
 	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,


### PR DESCRIPTION
## 변경 내용 

- 이제는 REQUEST URI 로그에서 파라미터가 없을 때 ?가 찍히지 않습니다.
- 이제는 REQUEST BODY 로그가 너무 길 때 100개의 문자만 찍힙니다.
- RequestCachingFilter의 이름이 기능을 잘 설명해주지 못하여 RequestLoggingFilter로 이름을 변경하였습니다.

## 특이 사항

- 

## 체크리스트

- [x] PR 날리기 전에 main branch pull 받으셨나요?
- [x] application.properties 등 노출되지 않아야 하는 파일이 올라가지는 않았나요?
- [x] 다른 담당자 파일을 수정한 부분에 대해서 이야기 하셨나요?
- [x] 주석 "상세히" 다셨나요?
- [x] 제출하기 전에 테스트코드 돌려 보셨나요?

closes #88 
