### PR TITLE
[#91] docs: DocumentController의 swagger에서 ResponseTemplate 전체를 보여줄 수 있도록 수정

### DIFF
--- a/src/main/java/goorm/eagle7/stelligence/domain/document/DocumentController.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/document/DocumentController.java
@@ -19,9 +19,6 @@ import goorm.eagle7.stelligence.domain.document.graph.dto.DocumentGraphResponse;
 import goorm.eagle7.stelligence.domain.document.graph.dto.DocumentNodeResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.ArraySchema;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -45,10 +42,7 @@ public class DocumentController {
 	@ApiResponse(
 		responseCode = "200",
 		description = "문서 생성 성공",
-		content = @Content(
-			mediaType = "application/json",
-			schema = @Schema(implementation = DocumentResponse.class)
-		)
+		useReturnTypeSchema = true
 	)
 	@PostMapping
 	public ResponseTemplate<DocumentResponse> createDocument(
@@ -62,10 +56,7 @@ public class DocumentController {
 	@ApiResponse(
 		responseCode = "200",
 		description = "문서 조회 성공",
-		content = @Content(
-			mediaType = "application/json",
-			schema = @Schema(implementation = DocumentResponse.class)
-		)
+		useReturnTypeSchema = true
 	)
 	@GetMapping("/{documentId}")
 	public ResponseTemplate<DocumentResponse> getDocument(
@@ -82,10 +73,7 @@ public class DocumentController {
 	@ApiResponse(
 		responseCode = "200",
 		description = "문서 그래프 조회 성공",
-		content = @Content(
-			mediaType = "application/json",
-			schema = @Schema(implementation = DocumentGraphResponse.class)
-		)
+		useReturnTypeSchema = true
 	)
 	@GetMapping
 	public ResponseTemplate<DocumentGraphResponse> getDocumentGraph(
@@ -103,10 +91,7 @@ public class DocumentController {
 	@ApiResponse(
 		responseCode = "200",
 		description = "문서 노드 제목 조회 성공",
-		content = @Content(
-			mediaType = "application/json",
-			array = @ArraySchema(schema = @Schema(implementation = DocumentNodeResponse.class))
-		)
+		useReturnTypeSchema = true
 	)
 	@GetMapping("/search")
 	public ResponseTemplate<List<DocumentNodeResponse>> searchDocument(


### PR DESCRIPTION
## 변경 내용 

- DocumentController의 swagger의 성공 ResponseExample에서 ResponseTemplate의 results만 보여주던 문제가 있었습니다.
- 이제는 ResponseTemplate 전체를 보여줄 수 있도록 수정하였습니다.

## 특이 사항

- X

## 체크리스트

- [x] PR 날리기 전에 main branch pull 받으셨나요?
- [x] application.properties 등 노출되지 않아야 하는 파일이 올라가지는 않았나요?
- [x] 다른 담당자 파일을 수정한 부분에 대해서 이야기 하셨나요?
- [x] 주석 "상세히" 다셨나요?
- [x] 제출하기 전에 테스트코드 돌려 보셨나요?

closes #
