### PR TITLE
90 section member mapping

### DIFF
--- a/src/main/java/goorm/eagle7/stelligence/common/merge/MergeService.java
+++ b/src/main/java/goorm/eagle7/stelligence/common/merge/MergeService.java
@@ -52,7 +52,7 @@ public class MergeService {
 		 */
 		amendments.forEach(amendment ->
 			amendmentMergeTemplateMapper.getTemplateForType(amendment.getType())
-				.handle(document, contribute.getContributor(), amendment)
+				.handle(document, contribute.getMember(), amendment)
 		);
 
 		document.incrementCurrentRevision();

--- a/src/main/java/goorm/eagle7/stelligence/common/merge/MergeService.java
+++ b/src/main/java/goorm/eagle7/stelligence/common/merge/MergeService.java
@@ -52,7 +52,7 @@ public class MergeService {
 		 */
 		amendments.forEach(amendment ->
 			amendmentMergeTemplateMapper.getTemplateForType(amendment.getType())
-				.handle(document, amendment)
+				.handle(document, contribute.getContributor(), amendment)
 		);
 
 		document.incrementCurrentRevision();

--- a/src/main/java/goorm/eagle7/stelligence/common/merge/template/AmendmentMergeTemplate.java
+++ b/src/main/java/goorm/eagle7/stelligence/common/merge/template/AmendmentMergeTemplate.java
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Component;
 
 import goorm.eagle7.stelligence.domain.amendment.model.Amendment;
 import goorm.eagle7.stelligence.domain.document.content.model.Document;
+import goorm.eagle7.stelligence.domain.member.model.Member;
 import goorm.eagle7.stelligence.domain.section.SectionRepository;
 import goorm.eagle7.stelligence.domain.section.model.Section;
 import lombok.RequiredArgsConstructor;
@@ -26,10 +27,11 @@ public abstract class AmendmentMergeTemplate {
 	 * 이렇게 생성된 Section은 SectionRepository를 통해 저장됩니다.
 	 *
 	 * @param document 섹션이 생성될 Document
+	 * @param contributor 섹션을 생성한 Member
 	 * @param amendment 섹션을 생성하기 위한 정보를 담고 있는 Amendment
 	 * @return 새로 생성된 섹션으로 DB에 저장되지 않은 상태입니다.
 	 */
-	abstract Section createSection(Document document, Amendment amendment);
+	abstract Section createSection(Document document, Member contributor, Amendment amendment);
 
 	/**
 	 * Amendment Type에 따라 서로 다른 방식의 추가 작업을 수행합니다.
@@ -37,17 +39,15 @@ public abstract class AmendmentMergeTemplate {
 	 */
 	abstract void afterMerged(Section section);
 
-	public final void handle(Document document, Amendment amendment) {
+	public final void handle(Document document, Member contributor, Amendment amendment) {
 		//템플릿에 따라 Section을 생성한다.
-		Section section = createSection(document, amendment);
+		Section section = createSection(document, contributor, amendment);
 
 		//템플릿에 상관없이 공통적으로 섹션을 저장한다.
 		sectionRepository.save(section);
 
-		/**
-		 * TODO : 이 부분에서 Member의 Contribute를 올려주는 코드 작성
-		 */
-
+		contributor.incrementContributes();
+		
 		//템플릿에 따라 추가적인 작업을 수행한다.
 		afterMerged(section);
 	}

--- a/src/main/java/goorm/eagle7/stelligence/common/merge/template/CreateAmendmentMergeTemplate.java
+++ b/src/main/java/goorm/eagle7/stelligence/common/merge/template/CreateAmendmentMergeTemplate.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Component;
 import goorm.eagle7.stelligence.common.sequence.SectionIdGenerator;
 import goorm.eagle7.stelligence.domain.amendment.model.Amendment;
 import goorm.eagle7.stelligence.domain.document.content.model.Document;
+import goorm.eagle7.stelligence.domain.member.model.Member;
 import goorm.eagle7.stelligence.domain.section.SectionRepository;
 import goorm.eagle7.stelligence.domain.section.model.Section;
 
@@ -34,13 +35,15 @@ public class CreateAmendmentMergeTemplate extends AmendmentMergeTemplate {
 	 * 수정안의 정보를 바탕으로 새로운 섹션을 생성합니다.
 	 *
 	 * @param document 섹션이 생성될 Document
+	 * @param contributor 섹션을 생성한 Member
 	 * @param amendment 섹션을 생성하기 위한 정보를 담고 있는 Amendment
 	 * @return 새로 생성된 섹션으로 DB에 저장되지 않은 상태입니다.
 	 */
 	@Override
-	Section createSection(Document document, Amendment amendment) {
+	Section createSection(Document document, Member contributor, Amendment amendment) {
 		return Section.createSection(
 			document,
+			contributor,
 			sectionIdGenerator.getAndIncrementSectionId(), //새로운 섹션의 삽입이므로 ID를 새로 생성합니다.
 			document.getCurrentRevision() + 1,
 			amendment.getNewSectionHeading(),

--- a/src/main/java/goorm/eagle7/stelligence/common/merge/template/DeleteAmendmentMergeTemplate.java
+++ b/src/main/java/goorm/eagle7/stelligence/common/merge/template/DeleteAmendmentMergeTemplate.java
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Component;
 
 import goorm.eagle7.stelligence.domain.amendment.model.Amendment;
 import goorm.eagle7.stelligence.domain.document.content.model.Document;
+import goorm.eagle7.stelligence.domain.member.model.Member;
 import goorm.eagle7.stelligence.domain.section.SectionRepository;
 import goorm.eagle7.stelligence.domain.section.model.Section;
 
@@ -25,13 +26,15 @@ public class DeleteAmendmentMergeTemplate extends AmendmentMergeTemplate {
 	 * 섹션의 heading, title, content는 null로 설정합니다.
 	 *
 	 * @param document 섹션이 생성될 Document
+	 * @param contributor 섹션을 생성한 Member
 	 * @param amendment 섹션을 생성하기 위한 정보를 담고 있는 Amendment
 	 * @return 새로 생성된 섹션으로 DB에 저장되지 않은 상태입니다.
 	 */
 	@Override
-	Section createSection(Document document, Amendment amendment) {
+	Section createSection(Document document, Member contributor, Amendment amendment) {
 		return Section.createSection(
 			document,
+			contributor,
 			amendment.getTargetSection().getId(),
 			document.getCurrentRevision() + 1,
 			null,

--- a/src/main/java/goorm/eagle7/stelligence/common/merge/template/UpdateAmendmentMergeTemplate.java
+++ b/src/main/java/goorm/eagle7/stelligence/common/merge/template/UpdateAmendmentMergeTemplate.java
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Component;
 
 import goorm.eagle7.stelligence.domain.amendment.model.Amendment;
 import goorm.eagle7.stelligence.domain.document.content.model.Document;
+import goorm.eagle7.stelligence.domain.member.model.Member;
 import goorm.eagle7.stelligence.domain.section.SectionRepository;
 import goorm.eagle7.stelligence.domain.section.model.Section;
 
@@ -27,13 +28,15 @@ public class UpdateAmendmentMergeTemplate extends AmendmentMergeTemplate {
 	 * 순서는 기존의 순서를 따라야합니다.
 	 *
 	 * @param document 섹션이 생성될 Document
+	 * @param contributor 섹션을 생성한 Member
 	 * @param amendment 섹션을 생성하기 위한 정보를 담고 있는 Amendment
 	 * @return 새로 생성된 섹션으로 DB에 저장되지 않은 상태입니다.
 	 */
 	@Override
-	Section createSection(Document document, Amendment amendment) {
+	Section createSection(Document document, Member contributor, Amendment amendment) {
 		return Section.createSection(
 			document,
+			contributor,
 			amendment.getTargetSection().getId(), //기존 섹션의 ID를 그대로 사용합니다.
 			document.getCurrentRevision() + 1,
 			amendment.getNewSectionHeading(),

--- a/src/main/java/goorm/eagle7/stelligence/domain/document/content/DocumentContentService.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/document/content/DocumentContentService.java
@@ -54,7 +54,7 @@ public class DocumentContentService {
 
 		//section 생성
 		for (int order = 0; order < sectionRequests.size(); order++) {
-			Section section = Section.createSection(document, sectionIdGenerator.getAndIncrementSectionId(), 1L,
+			Section section = Section.createSection(document, author, sectionIdGenerator.getAndIncrementSectionId(), 1L,
 				sectionRequests.get(order).getHeading(), sectionRequests.get(order).getTitle(),
 				sectionRequests.get(order).getContent(), order + 1);
 

--- a/src/main/java/goorm/eagle7/stelligence/domain/section/model/Section.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/section/model/Section.java
@@ -1,14 +1,15 @@
 package goorm.eagle7.stelligence.domain.section.model;
 
-import static jakarta.persistence.FetchType.*;
 import static lombok.AccessLevel.*;
 
 import goorm.eagle7.stelligence.common.entity.BaseTimeEntity;
 import goorm.eagle7.stelligence.domain.document.content.model.Document;
+import goorm.eagle7.stelligence.domain.member.model.Member;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
 import jakarta.persistence.IdClass;
 import jakarta.persistence.JoinColumn;
@@ -34,10 +35,15 @@ public class Section extends BaseTimeEntity implements Comparable<Section> {
 	@Id
 	private Long revision;
 
-	//Member
+	/**
+	 * Section의 작성자입니다.
+	 */
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "author_id")
+	private Member author;
 
 	//Document
-	@ManyToOne(fetch = LAZY)
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "document_id")
 	private Document document;
 
@@ -55,6 +61,7 @@ public class Section extends BaseTimeEntity implements Comparable<Section> {
 	//===생성===//
 	public static Section createSection(
 		Document document,
+		Member author,
 		Long id,
 		Long revision,
 		Heading heading,
@@ -64,6 +71,7 @@ public class Section extends BaseTimeEntity implements Comparable<Section> {
 	) {
 		Section section = new Section();
 		section.document = document;
+		section.author = author;
 		section.id = id;
 		section.revision = revision;
 		section.heading = heading;

--- a/src/test/java/goorm/eagle7/stelligence/domain/document/content/DocumentContentServiceCreateUnitTest.java
+++ b/src/test/java/goorm/eagle7/stelligence/domain/document/content/DocumentContentServiceCreateUnitTest.java
@@ -83,6 +83,10 @@ class DocumentContentServiceCreateUnitTest {
 		assertThat(document.getSections().get(1).getTitle()).isEqualTo("title2");
 		assertThat(document.getSections().get(0).getOrder()).isEqualTo(1);
 		assertThat(document.getSections().get(1).getOrder()).isEqualTo(2);
+
+		//section의 member 값이 정상적으로 들어갔는지 확인
+		assertThat(document.getSections().get(0).getAuthor().getId()).isEqualTo(1L);
+		assertThat(document.getSections().get(1).getAuthor().getId()).isEqualTo(1L);
 	}
 
 }


### PR DESCRIPTION
## 변경 내용 

- 이제는 Section이 누구로부터 작성되었는지 추적이 가능합니다.
  - Section에 Member 엔티티를 멤버변수로 추가하고 Section의 팩터리 메서드에 Member를 받을 수 있도록 만들었습니다.
  - 섹션을 생성하는 모든 파트에서 Member를 전달해주었습니다.

## 특이 사항

- 

## 체크리스트

- [x] PR 날리기 전에 main branch pull 받으셨나요?
- [x] application.properties 등 노출되지 않아야 하는 파일이 올라가지는 않았나요?
- [x] 다른 담당자 파일을 수정한 부분에 대해서 이야기 하셨나요?
- [x] 주석 "상세히" 다셨나요?
- [x] 제출하기 전에 테스트코드 돌려 보셨나요?

closes #90 
