### PR TITLE
[#104] chore: fulltext index의 분석기를 기본 분석기로 변경

### DIFF
--- a/src/main/java/goorm/eagle7/stelligence/api/DatabaseConnectionApplicationRunner.java
+++ b/src/main/java/goorm/eagle7/stelligence/api/DatabaseConnectionApplicationRunner.java
@@ -66,13 +66,13 @@ public class DatabaseConnectionApplicationRunner implements ApplicationRunner {
 
 		// neo4j의 fulltextindex를 체크하는 로직
 		try {
-			// `fulltext.analyzer`: 'cjk'는 중/일/한국어 특화 분석기
+			// `fulltext.analyzer`: 'cjk'는 중/일/한국어 특화 분석기 -> 'standard-no-stop-words'로 변경
 			// `fulltext.eventually_consistent`: false : 삽입에 대해 인덱싱을 지연하지 않고 즉시 적용
 			String neo4jFulltextIndexQuery = "create fulltext index documentTitleIndex"
 				+ " if not exists for (n:DocumentNode) on each [n.title]"
 				+ " OPTIONS {"
 				+ "  indexConfig: {"
-				+ "    `fulltext.analyzer`: 'cjk', `fulltext.eventually_consistent`: false"
+				+ "    `fulltext.analyzer`: 'standard-no-stop-words', `fulltext.eventually_consistent`: false"
 				+ "  }"
 				+ " };";
 			neo4jClient.query(neo4jFulltextIndexQuery).run();


### PR DESCRIPTION
## 변경 내용 

- 분석기를 바꾸었고 이제 3글자 이상에서도 잘 검색되는 것을 확인했습니다.

## 특이 사항

- 이미 neo4j 운영환경에도 적용되어 있어 천천히 머지/배포해도 됩니다.

## 체크리스트

- [x] PR 날리기 전에 main branch pull 받으셨나요?
- [x] application.properties 등 노출되지 않아야 하는 파일이 올라가지는 않았나요?
- [x] 다른 담당자 파일을 수정한 부분에 대해서 이야기 하셨나요?
- [x] 주석 "상세히" 다셨나요?
- [x] 제출하기 전에 테스트코드 돌려 보셨나요?

closes #
