### PR TITLE
95 백엔드 모니터링 관련 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'  //actuator 추가
 
+    implementation 'io.micrometer:micrometer-registry-prometheus'   //마이크로미터 프로메테우스 구현체
+
     //database driver
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'  //actuator 추가
 
     //database driver
     runtimeOnly 'com.h2database:h2'

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -15,3 +15,9 @@ logging.level.goorm.eagle7.stelligence=debug
 ## Swagger API Docs Path
 springdoc.swagger-ui.path=/api-docs
 spring.jpa.properties.hibernate.default_batch_fetch_size=100
+
+## actuator ??
+management.server.port=8082
+management.endpoints.web.exposure.include=*
+management.endpoint.health.show-components=always
+server.tomcat.mbeanregistry.enabled=true

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -21,6 +21,6 @@ contribute.scheduler.overlap-minutes=5
 
 ## actuator properties
 management.server.port=8082
-management.endpoints.web.exposure.include=*
+management.endpoints.web.exposure.include=health,prometheus,loggers
 management.endpoint.health.show-components=always
 server.tomcat.mbeanregistry.enabled=true

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -16,7 +16,7 @@ logging.level.goorm.eagle7.stelligence=debug
 springdoc.swagger-ui.path=/api-docs
 spring.jpa.properties.hibernate.default_batch_fetch_size=100
 
-## actuator ??
+## actuator properties
 management.server.port=8082
 management.endpoints.web.exposure.include=*
 management.endpoint.health.show-components=always


### PR DESCRIPTION
## 변경 내용 

- 백엔드 모니터링 툴 적용을 위해 build.gradle에 의존성을 추가했습니다.
  - 스프링 액츄에이터 (마이크로미터 내장)
  - 마이크로미터 프로메테우스 구현체
- 백엔드 모니터링 툴 적용을 위해 application-local.properties에 내용을 추가했습니다.
  - 8082 포트를 모니터링을 위한 포트로 설정
  - health, prometheus, loggers에 대한 정보를 확인할 수 있도록 엔드포인트 노출
  - health는 각 컴포넌트의 상태를 알 수 있도록 설정
  - 톰캣의 스레드 정보 등을 알 수 있도록 설정

## 특이 사항

- X

## 체크리스트

- [x] PR 날리기 전에 main branch pull 받으셨나요?
- [x] application.properties 등 노출되지 않아야 하는 파일이 올라가지는 않았나요?
- [x] 다른 담당자 파일을 수정한 부분에 대해서 이야기 하셨나요?
- [x] 주석 "상세히" 다셨나요?
- [x] 제출하기 전에 테스트코드 돌려 보셨나요?

closes #
