### PR TITLE
126 JaCoCo 도입

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.2.1'
     id 'io.spring.dependency-management' version '1.1.4'
+    id 'jacoco'
 }
 
 group = 'goorm.eagle7'
@@ -71,6 +72,7 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+    finalizedBy 'jacocoTestReport'
 }
 
 // === ⭐ QueryDsl 빌드 옵션 (선택) ===
@@ -86,4 +88,37 @@ tasks.withType(JavaCompile) {
 
 clean.doLast {
     file(querydslDir).deleteDir()
+}
+
+// jacoco 설정
+jacoco {
+    // JaCoCo 버전
+    toolVersion = "0.8.11"
+
+    //  테스트결과 리포트를 저장할 경로 변경
+    //  default는 "$/jacoco"
+    //  reportsDir = file("$buildDir/customJacocoReportDir")
+}
+
+/**
+ * 바이너리 커버리지 결과를 사람이 읽기 좋은 형태의 리포트로 저장합니다.
+ * html 파일로 생성해 사람이 쉽게 눈으로 확인할 수도 있고,
+ * SonarQube 등으로 연동하기 위해 xml, csv 같은 형태로도 리포트를 생성할 수 있습니다.
+ */
+jacocoTestReport {
+    afterEvaluate {
+        classDirectories.setFrom(files(classDirectories.files.collect {
+            fileTree(dir: it,
+                    exclude: [ // 필터링할 파일 목록
+                               '**/dto/**',
+                               '**/Q*',
+                               'goorm/eagle7/stelligence/api/**',
+                    ])
+        }))
+    }
+    reports {
+        html {
+            enabled true
+        }
+    }
 }

--- a/src/test/java/goorm/eagle7/stelligence/domain/document/content/DocumentContentServiceReadUnitTest.java
+++ b/src/test/java/goorm/eagle7/stelligence/domain/document/content/DocumentContentServiceReadUnitTest.java
@@ -129,4 +129,18 @@ class DocumentContentServiceReadUnitTest {
 			.isInstanceOf(BaseException.class)
 			.hasMessage("존재하지 않는 버전입니다. 버전 : 4");
 	}
+
+	@Test
+	@DisplayName("특정 내용을 담고 있는 문서의 ID 목록 조회")
+	void getDocumentIdWhichContainsKeywordInLatestVersionSuccess() {
+		//given
+		when(documentContentRepository.findDocumentIdWhichContainsKeywordInLatestVersion("keyword"))
+			.thenReturn(List.of(1L, 2L, 3L));
+
+		//when
+		List<Long> documentIds = documentContentService.findDocumentWhichContainsKeyword("keyword");
+		//then
+		assertThat(documentIds).hasSize(3);
+		assertThat(documentIds).containsExactly(1L, 2L, 3L);
+	}
 }


### PR DESCRIPTION
## 변경 내용 

- 테스트 품질 관리를 위한 JaCoCo 라이브러리를 도입했습니다.
- 테스트를 수행하면 build/reports/test/html 하위에 index.html이 생기는데, 이 파일을 열어 테스트 정보를 확인할 수 있습니다.

## 체크리스트

- [x] PR 날리기 전에 main branch pull 받으셨나요?
- [x] application.properties 등 노출되지 않아야 하는 파일이 올라가지는 않았나요?
- [x] 다른 담당자 파일을 수정한 부분에 대해서 이야기 하셨나요?
- [x] 주석 "상세히" 다셨나요?
- [x] 제출하기 전에 테스트코드 돌려 보셨나요?

closes #126 
