### PR TITLE
[#129] test: MemberService test 생성

### DIFF
--- a/src/test/java/goorm/eagle7/stelligence/domain/member/MemberServiceTest.java
+++ b/src/test/java/goorm/eagle7/stelligence/domain/member/MemberServiceTest.java
@@ -1,0 +1,244 @@
+package goorm.eagle7.stelligence.domain.member;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import goorm.eagle7.stelligence.api.exception.BaseException;
+import goorm.eagle7.stelligence.config.mockdata.TestFixtureGenerator;
+import goorm.eagle7.stelligence.domain.member.dto.MemberSimpleResponse;
+import goorm.eagle7.stelligence.domain.member.dto.MemberDetailResponse;
+import goorm.eagle7.stelligence.domain.member.dto.MemberUpdateNicknameRequest;
+import goorm.eagle7.stelligence.domain.member.model.Member;
+
+@ExtendWith(MockitoExtension.class)
+class MemberServiceTest {
+
+	@Mock
+	private MemberRepository memberRepository;
+	@InjectMocks
+	private MemberService memberService;
+
+	private Member stdMember;
+
+	/**
+	 * <h2>테스트에 사용할 Member 객체 생성</h2>
+	 */
+	@BeforeEach
+	void setUp() {
+		stdMember = TestFixtureGenerator.member(1L, "stdNickname");
+	}
+
+	/**
+	 * <h2>[예외] private findMemberById() 우회 테스트</h2>
+	 * <p>- 다른 메서드에서 예외 발생 혹은 Member 얻는 용도로 사용하는 private 메서드</p>
+	 * <p>- getProfileById 메서드로 우회해 예외 발생 테스트 진행</p>
+	 * <p>결과: 해당 멤버를 찾을 수 없을 때 BaseException 발생</p>
+	 * <p>검증 방식: Repository 호출 횟수, 예외 발생 여부, 예외 메시지</p>
+	 * @see MemberService#findMemberById(Long)
+	 * @see MemberService#getProfileById(Long)
+	 */
+	@Test
+	@DisplayName("[예외] 해당 멤버를 찾을 수 없을 때 BaseException 발생 - private findMemberById() ")
+	void findMemberByIdThrows() {
+
+		// given - Repository에서 findById()가 호출되면 BaseException 발생하도록 설정
+		Long stdMemberId = stdMember.getId();
+		when(memberRepository.findById(stdMemberId))
+			.thenThrow(
+				new BaseException(String.format("해당 멤버를 찾을 수 없습니다. MemberId= %s", stdMemberId))
+			);
+
+		// when
+
+		// then
+		// Repository의 findById()가 호출됐는지 확인 - 0번
+		// throw new BaseException()이므로 호출되지 않음
+		verify(memberRepository, times(0)).findById(stdMemberId);
+
+		// 존재하지 않는 멤버를 조회했을 때 발생하는 BaseException 및 메시지 확인
+		assertThatThrownBy(() -> memberService.getProfileById(stdMemberId))
+			.isInstanceOf(BaseException.class)
+			.hasMessage(String.format("해당 멤버를 찾을 수 없습니다. MemberId= %s", stdMemberId));
+
+	}
+
+	/**
+	 * <h2>[정상] Member를 반환하는 private 메서드 테스트</h2>
+	 * <p>결과: MemberProfileResponse 반환</p>
+	 * <p>검증 방식: repository 호출 횟수, 반환값과 기댓값의 Class, 동등성 비교</p>
+	 * @see MemberService#getProfileById(Long)
+	 */
+	@Test
+	@DisplayName("[정상] memberId로 MemberProfile 반환(private 메서드라 우회) - getProfileById")
+	void getProfileById() {
+
+		// given - Repository에서 findById()가 호출되면 stdMember를 반환하도록 설정
+		when(memberRepository.findById(stdMember.getId())).thenReturn(Optional.of(stdMember));
+
+		// when
+		// MemberService의 getProfileById()가 실제 호출됐을 때 actualResponse 반환
+		MemberDetailResponse actualResponse = memberService.getProfileById(stdMember.getId());
+		// 기대하는 expectedResponse 생성
+		MemberDetailResponse expectedResponse = MemberDetailResponse.from(stdMember);
+
+		// then
+		// Repository의 findById()가 호출됐는지 확인 - 1번
+		verify(memberRepository, times(1)).findById(stdMember.getId());
+		// actualResponse와 expectedResponse가 같은지 해당 클래스 확인
+		assertThat(actualResponse).hasSameClassAs(expectedResponse);
+		// actualResponse와 expectedResponse의 내용까지 같은지(동등성) 확인
+		assertThat(actualResponse).usingRecursiveComparison().isEqualTo(expectedResponse);
+
+	}
+
+	/**
+	 * <h2>[정상] MemberId로 회원 탈퇴 테스트</h2>
+	 * <p>결과: deleteById()가 호출되고, 아무 일도 일어나지 않음.</p>
+	 * <p>검증 방식: deleteById() 호출 횟수</p>
+	 * @see MemberService#delete(Long)
+	 */
+	@Test
+	@DisplayName("[정상] memberId로 회원 탈퇴 - delete")
+	void deleteExistentMember() {
+
+		// given
+		Long memberId = stdMember.getId();
+		doNothing().when(memberRepository).deleteById(memberId);
+
+		// when
+		memberService.delete(memberId);
+
+		// then - 존재하는 memberId면 deleteById()가 호출되고, 아무 일도 일어나지 않음.
+		verify(memberRepository, times(1)).deleteById(memberId);
+
+	}
+
+	/**
+	 * <h2>[예외] 존재하지 않는 memberId에 대한 회원 탈퇴 테스트</h2>
+	 * <p>결과: 존재하지 않더라도, deleteById()가 호출되고, 아무 일도 일어나지 않음.</p>
+	 * <p>검증 방식: deleteById() 호출 횟수</p>
+	 * @see MemberService#delete(Long)
+	 */
+	@Test
+	@DisplayName("[예외] 존재하지 않는 memberId에 대한 회원 탈퇴 - delete")
+	void deleteNonExistentMember() {
+
+		// given - 존재하지 않는 memberId
+		Long nonExistentMemberId = 999L;
+
+		// when
+		memberService.delete(nonExistentMemberId);
+
+		// then - 존재하지 않는 memberId여도 deleteById()가 호출되고, 아무 일도 일어나지 않음.
+		verify(memberRepository, times(1)).deleteById(nonExistentMemberId);
+
+	}
+
+	/**
+	 * <h2>[정상] 닉네임 수정 테스트</h2>
+	 * <p>결과: updateNickname()가 호출되고, 닉네임이 변경됨.'</p>
+	 * <p>검증 방식: existsByNickname() 호출 횟수, findById() 호출 횟수, 닉네임 변경 여부</p>
+	 * @see MemberService#updateNickname(Long, MemberUpdateNicknameRequest)
+	 */
+	@Test
+	@DisplayName("[정상] 닉네임 수정 - updateNickname")
+	void updateNickname() {
+
+		// given - 중복이 아닌, 새로운 닉네임
+		Long memberId = stdMember.getId();
+		String newNickname = "newNickname";
+		MemberUpdateNicknameRequest nicknameRequest = MemberUpdateNicknameRequest.from(newNickname);
+		when(memberRepository.existsByNickname(newNickname)).thenReturn(false);
+		when(memberRepository.findById(memberId)).thenReturn(Optional.of(stdMember));
+
+		// when - 새로운 닉네임으로 update 시도
+		memberService.updateNickname(memberId, nicknameRequest);
+
+		// then
+		// memberRepository의 existsByNickname()가 호출되는지 확인
+		verify(memberRepository, times(1)).existsByNickname(newNickname);
+		// memberRepository의 findById()가 호출되는지 확인
+		verify(memberRepository, times(1)).findById(memberId);
+		// nickname이 변경되었는지 확인 // TODO member.updateNickname() 메서드는 통합 테스트가 아니어도 가능한지 확인
+		assertThat(stdMember.getNickname()).isEqualTo(newNickname);
+
+	}
+
+	/**
+	 * <h2>[예외]  중복 닉네임으로 닉네임 수정 요청 테스트</h2>
+	 * <p>결과: updateNickname()가 호출되지 않고, 닉네임이 변경되지 않음. Exception 발생 </p>
+	 * <p>검증 방식: existsByNickname() 호출 횟수, findById() 호출 횟수, 닉네임 변경 여부, 예외 확인</p>
+	 * @see MemberService#updateNickname(Long, MemberUpdateNicknameRequest)
+	 */
+	@Test
+	@DisplayName("[예외] 중복 닉네임으로 닉네임 수정 요청 - updateNickname")
+	void updateNicknameThrows() {
+
+		// given - 이미 존재하는 닉네임
+		Long memberId = stdMember.getId();
+		String stdNickname = stdMember.getNickname();
+		String newNickname = "newNickname";
+		MemberUpdateNicknameRequest nicknameRequest = MemberUpdateNicknameRequest.from(newNickname);
+		when(memberRepository.findById(memberId)).thenReturn(Optional.of(stdMember));
+		when(memberRepository.existsByNickname(newNickname)).thenReturn(true);
+
+		// when - 이미 존재하는 닉네임으로 update 시도
+
+		// then
+		// memberRepository의 existsByNickname()가 호출되는지 확인 - 예외이므로 0번
+		verify(memberRepository, times(0)).existsByNickname(newNickname);
+		// memberRepository의 findById()가 호출되는지 확인 - 예외이므로 0번
+		verify(memberRepository, times(0)).findById(memberId);
+		// nickname이 변경되었는지 확인 - 예외이므로 바뀌지 않고, 기존 그대로
+		assertThat(stdMember.getNickname()).isEqualTo(stdNickname);
+		// 중복 닉네임인 경우 발생하는 BaseException 및 메시지 확인
+		assertThatThrownBy(() -> memberService.updateNickname(memberId, nicknameRequest))
+			.isInstanceOf(BaseException.class)
+			.hasMessage(String.format("이미 사용 중인 닉네임입니다. nickname=%s", newNickname));
+
+	}
+
+	/**
+	 * <h2>[정상] memberId로 MiniProfile 반환 테스트</h2>
+	 * <p>결과: MemberMiniProfileResponse 반환</p>
+	 * <p>검증 방식: repository 호출 횟수, 반환값과 기댓값의 Class, 동등성 비교</p>
+	 * @see MemberService#getMiniProfileById(Long)
+	 */
+	@Test
+	@DisplayName("[정상] memberId로 MiniProfile 반환 - getMiniProfileById")
+	void getMiniProfileById() {
+
+		// given - Repository에서 findById()가 호출되면 stdMember를 반환하도록 설정
+		when(memberRepository.findById(stdMember.getId())).thenReturn(Optional.of(stdMember));
+
+		// when
+		// MemberService의 getMiniProfileById()가 실제 호출됐을 때 actualResponse 반환
+		MemberSimpleResponse actualResponse = memberService.getMiniProfileById(stdMember.getId());
+		// 기대하는 expectedResponse 생성
+		MemberSimpleResponse expectedResponse = MemberSimpleResponse.of(
+			stdMember.getId(),
+			stdMember.getNickname(),
+			stdMember.getImageUrl()
+		);
+
+		// then
+		// Repository의 findById()가 호출됐는지 확인 - 1번
+		verify(memberRepository, times(1)).findById(stdMember.getId());
+		// actualResponse와 expectedResponse가 같은지 해당 클래스 확인
+		assertThat(actualResponse).hasSameClassAs(expectedResponse);
+		// actualResponse와 expectedResponse의 내용까지 같은지(동등성) 확인
+		assertThat(actualResponse).usingRecursiveComparison().isEqualTo(expectedResponse);
+
+	}
+
+}


### PR DESCRIPTION
## 변경 내용 
- MemberService test 생성했습니다.

## 특이 사항
- PR Merge를 기다리며... test를.... 만들었습니다.....

## 체크리스트

- [X] PR 날리기 전에 main branch pull 받으셨나요?
- [X] application.properties 등 노출되지 않아야 하는 파일이 올라가지는 않았나요?
- [X] 다른 담당자 파일을 수정한 부분에 대해서 이야기 하셨나요?
- [X] 주석 "상세히" 다셨나요?
- [X] 제출하기 전에 테스트코드 돌려 보셨나요?

closes #129
---
# [01/30] PR Review 반영 
- 범석님 구두 Review
## service에서 blackbox test로 진행하도록 변경
- given: service 로직 내에서 검증 시에 필요한 행동만 mocking
- then: 자세한 service 로직(구현 내용)이 변경되어도 수행해야 할 일 검증
  - when (해당 메서드 수행) 이후 verify, assertThat 등 검증해야 함.
  - 이 과정에서 상세 구현 로직까지 검증(verity, assertThat)하지 않음.
  - repository를 mocking 시 repository의 일만 mocking(service 로직에서 실행되어야 하는 일과 분리)
- 검증해야 하는 핵심 로직이 아닌 메서드 등을 의존하지 않도록 주의
  - test 내에서 string.format, from 등을 사용하게 되면 해당 메서드에 의존하게 되기 때문에 예상하는 값을 하드 코딩으로 비교.

- TODO: 반환 DTO의 from 등에 의존하는 방식 개선, verify 등의 적절성 확인 필요.