### PR TITLE
138 feat: 문서 내용 조회시 캐싱 적용

### DIFF
--- a/src/main/java/goorm/eagle7/stelligence/domain/document/content/DocumentContentService.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/document/content/DocumentContentService.java
@@ -2,6 +2,7 @@ package goorm.eagle7.stelligence.domain.document.content;
 
 import java.util.List;
 
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -69,7 +70,7 @@ public class DocumentContentService {
 	 * @param documentId 조회할 Document의 ID
 	 * @return 최신 Document의 Response Object
 	 */
-	// @Cacheable(value = "document", key = "#documentId", cacheManager = "cacheManager")
+	@Cacheable(value = "document", key = "#documentId", cacheManager = "cacheManager")
 	public DocumentResponse getDocument(Long documentId) {
 		Document document = documentRepository.findById(documentId)
 			.orElseThrow(() -> new BaseException("문서가 존재하지 않습니다. 문서 ID : " + documentId));

--- a/src/test/java/goorm/eagle7/stelligence/domain/contribute/scheduler/MergeHandlerTest.java
+++ b/src/test/java/goorm/eagle7/stelligence/domain/contribute/scheduler/MergeHandlerTest.java
@@ -11,6 +11,7 @@ import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.cache.CacheManager;
 
 import goorm.eagle7.stelligence.domain.amendment.model.Amendment;
 import goorm.eagle7.stelligence.domain.amendment.model.AmendmentType;
@@ -31,6 +32,9 @@ class MergeHandlerTest {
 
 	@Mock
 	ContributeRepository contributeRepository;
+
+	@Mock
+	CacheManager cacheManager;
 
 	@Mock
 	CreateAmendmentMergeTemplate createAmendmentMergeTemplate;


### PR DESCRIPTION
## 변경 내용 

- MergeHandler의 파라미터가 Contribute 타입에서 Long contributeId로 바뀌면서 메서드 시그니처를 통해 캐시를 무효화 할 수 있는 방법이 제한되었던 문제가 있었습니다. (기존에는 #contribute.document.id 를 통해 캐시 무효화)
- 이를 해결하기 위해 CacheManager를 의존주입 받아 직접 evict를 수행하게 만들었습니다.


## 체크리스트

- [x] PR 날리기 전에 main branch pull 받으셨나요?
- [x] application.properties 등 노출되지 않아야 하는 파일이 올라가지는 않았나요?
- [x] 다른 담당자 파일을 수정한 부분에 대해서 이야기 하셨나요?
- [x] 주석 "상세히" 다셨나요?
- [x] 제출하기 전에 테스트코드 돌려 보셨나요?

closes #138 
