### PR TITLE
127 토론 서비스 로직 개발

### DIFF
--- a/src/main/java/goorm/eagle7/stelligence/domain/debate/DebateController.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/debate/DebateController.java
@@ -50,7 +50,7 @@ public class DebateController {
 		@ParameterObject
 		@PageableDefault(page = 0, size = 10) Pageable pageable
 	) {
-		return ResponseTemplate.ok(null);
+		return ResponseTemplate.ok(debateService.getDebatePage(status, pageable));
 	}
 
 	@Operation(summary = "토론 상세 조회", description = "특정 토론을 조회합니다.")

--- a/src/main/java/goorm/eagle7/stelligence/domain/debate/DebateController.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/debate/DebateController.java
@@ -35,6 +35,8 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class DebateController {
 
+	private final DebateService debateService;
+
 	@Operation(summary = "토론 리스트 조회", description = "토론의 상태(OPEN / CLOSED)에 따라 토론 리스트를 조회합니다.")
 	@ApiResponse(
 		responseCode = "200",
@@ -62,7 +64,7 @@ public class DebateController {
 		@Parameter(description = "조회할 토론의 ID", example = "1")
 		@PathVariable("debateId") Long debateId
 	) {
-		return ResponseTemplate.ok(null);
+		return ResponseTemplate.ok(debateService.getDebateDetailById(debateId));
 	}
 
 	@Operation(summary = "토론 댓글 작성", description = "토론에 새로운 댓글을 작성합니다.")

--- a/src/main/java/goorm/eagle7/stelligence/domain/debate/DebateRepository.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/debate/DebateRepository.java
@@ -1,0 +1,8 @@
+package goorm.eagle7.stelligence.domain.debate;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import goorm.eagle7.stelligence.domain.debate.model.Debate;
+
+public interface DebateRepository extends JpaRepository<Debate, Long> {
+}

--- a/src/main/java/goorm/eagle7/stelligence/domain/debate/DebateRepository.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/debate/DebateRepository.java
@@ -1,8 +1,19 @@
 package goorm.eagle7.stelligence.domain.debate;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import goorm.eagle7.stelligence.domain.debate.model.Debate;
 
 public interface DebateRepository extends JpaRepository<Debate, Long> {
+
+	@Query("select d from Debate d"
+		+ " join fetch d.contribute c"
+		+ " join fetch c.member m"
+		+ " join fetch c.amendments a"
+		+ " where d.id = :debateId")
+	Optional<Debate> findByIdWithContribute(@Param("debateId") Long debateId);
 }

--- a/src/main/java/goorm/eagle7/stelligence/domain/debate/DebateRepository.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/debate/DebateRepository.java
@@ -2,11 +2,14 @@ package goorm.eagle7.stelligence.domain.debate;
 
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import goorm.eagle7.stelligence.domain.debate.model.Debate;
+import goorm.eagle7.stelligence.domain.debate.model.DebateStatus;
 
 public interface DebateRepository extends JpaRepository<Debate, Long> {
 
@@ -16,4 +19,12 @@ public interface DebateRepository extends JpaRepository<Debate, Long> {
 		+ " join fetch c.amendments a"
 		+ " where d.id = :debateId")
 	Optional<Debate> findByIdWithContribute(@Param("debateId") Long debateId);
+
+	@Query(value = "select d from Debate d"
+		+ " join fetch d.contribute c"
+		+ " where d.status = :status"
+		+ " order by d.createdAt desc",
+		countQuery = "select count(d) from Debate d"
+			+ " where d.status = :status")
+	Page<Debate> findPageByStatus(@Param("status") DebateStatus status, Pageable pageable);
 }

--- a/src/main/java/goorm/eagle7/stelligence/domain/debate/DebateService.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/debate/DebateService.java
@@ -48,7 +48,7 @@ public class DebateService {
 	/**
 	 * 특정 토론을 ID로 찾아서 조회합니다.
 	 * @param debateId: 조회할 토론의 ID
-	 * @return DebateResponse:
+	 * @return DebateResponse: 조회된 토론 응답 DTO
 	 */
 	@Transactional(readOnly = true)
 	public DebateResponse getDebateDetailById(Long debateId) {
@@ -57,6 +57,12 @@ public class DebateService {
 		return DebateResponse.of(findDebate);
 	}
 
+	/**
+	 * 토론의 상태(OPEN / CLOSED)에 따라 토론 리스트를 페이징을 적용하여 조회합니다.
+	 * @param status: 조회하려는 토론의 상태(OPEN / CLOSED)
+	 * @param pageable: 조회하려는 토론의 페이지 정보
+	 * @return DebatePageResponse: 조회된 토론 페이지 응답 DTO
+	 */
 	@Transactional(readOnly = true)
 	public DebatePageResponse getDebatePage(DebateStatus status, Pageable pageable) {
 

--- a/src/main/java/goorm/eagle7/stelligence/domain/debate/DebateService.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/debate/DebateService.java
@@ -1,0 +1,29 @@
+package goorm.eagle7.stelligence.domain.debate;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import goorm.eagle7.stelligence.domain.contribute.model.Contribute;
+import goorm.eagle7.stelligence.domain.debate.model.Debate;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional
+public class DebateService {
+
+	private final DebateRepository debateRepository;
+
+	/**
+	 * 수정요청을 토론으로 전환합니다.
+	 * 이때의 수정요청은 투표중인 상태여야합니다.
+	 * 수정요청의 스케쥴러에 의해서만 호출되어야하는 메서드입니다.
+	 * @param contribute: 토론으로 전환할 수정 요청
+	 */
+	public void convertToDebate(Contribute contribute) {
+		Debate debate = Debate.openFrom(contribute);
+		debateRepository.save(debate);
+	}
+}

--- a/src/main/java/goorm/eagle7/stelligence/domain/debate/DebateService.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/debate/DebateService.java
@@ -1,12 +1,16 @@
 package goorm.eagle7.stelligence.domain.debate;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import goorm.eagle7.stelligence.api.exception.BaseException;
 import goorm.eagle7.stelligence.domain.contribute.model.Contribute;
+import goorm.eagle7.stelligence.domain.debate.dto.DebatePageResponse;
 import goorm.eagle7.stelligence.domain.debate.dto.DebateResponse;
 import goorm.eagle7.stelligence.domain.debate.model.Debate;
+import goorm.eagle7.stelligence.domain.debate.model.DebateStatus;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -51,5 +55,12 @@ public class DebateService {
 		Debate findDebate = debateRepository.findByIdWithContribute(debateId)
 			.orElseThrow(() -> new BaseException("존재하지 않는 토론에 대한 조회 요청입니다. Debate ID: " + debateId));
 		return DebateResponse.of(findDebate);
+	}
+
+	@Transactional(readOnly = true)
+	public DebatePageResponse getDebatePage(DebateStatus status, Pageable pageable) {
+
+		Page<Debate> debatePage = debateRepository.findPageByStatus(status, pageable);
+		return DebatePageResponse.from(debatePage);
 	}
 }

--- a/src/main/java/goorm/eagle7/stelligence/domain/debate/DebateService.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/debate/DebateService.java
@@ -3,7 +3,9 @@ package goorm.eagle7.stelligence.domain.debate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import goorm.eagle7.stelligence.api.exception.BaseException;
 import goorm.eagle7.stelligence.domain.contribute.model.Contribute;
+import goorm.eagle7.stelligence.domain.debate.dto.DebateResponse;
 import goorm.eagle7.stelligence.domain.debate.model.Debate;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -37,5 +39,17 @@ public class DebateService {
 			.orElseThrow(() -> new IllegalArgumentException("삭제하려는 토론이 존재하지 않습니다. Debate ID: " + debateId));
 
 		targetDebate.close();
+	}
+
+	/**
+	 * 특정 토론을 ID로 찾아서 조회합니다.
+	 * @param debateId: 조회할 토론의 ID
+	 * @return DebateResponse:
+	 */
+	@Transactional(readOnly = true)
+	public DebateResponse getDebateDetailById(Long debateId) {
+		Debate findDebate = debateRepository.findByIdWithContribute(debateId)
+			.orElseThrow(() -> new BaseException("존재하지 않는 토론에 대한 조회 요청입니다. Debate ID: " + debateId));
+		return DebateResponse.of(findDebate);
 	}
 }

--- a/src/main/java/goorm/eagle7/stelligence/domain/debate/DebateService.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/debate/DebateService.java
@@ -26,4 +26,16 @@ public class DebateService {
 		Debate debate = Debate.openFrom(contribute);
 		debateRepository.save(debate);
 	}
+
+	/**
+	 * 특정 토론을 ID로 찾아서 종료합니다.
+	 * 토론의 스케쥴러에 의해서만 호출되어야하는 메서드입니다.
+	 * @param debateId: 종료할 토론의 ID
+	 */
+	public void closeDebateById(Long debateId) {
+		Debate targetDebate = debateRepository.findById(debateId)
+			.orElseThrow(() -> new IllegalArgumentException("삭제하려는 토론이 존재하지 않습니다. Debate ID: " + debateId));
+
+		targetDebate.close();
+	}
 }

--- a/src/main/java/goorm/eagle7/stelligence/domain/debate/dto/DebatePageResponse.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/debate/dto/DebatePageResponse.java
@@ -2,6 +2,9 @@ package goorm.eagle7.stelligence.domain.debate.dto;
 
 import java.util.List;
 
+import org.springframework.data.domain.Page;
+
+import goorm.eagle7.stelligence.domain.debate.model.Debate;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,4 +16,13 @@ public class DebatePageResponse {
 	private List<DebateSimpleResponse> debates;
 	private int totalPages;
 
+	public static DebatePageResponse from(Page<Debate> debatePage) {
+
+		return new DebatePageResponse(debatePage);
+	}
+
+	private DebatePageResponse(Page<Debate> debatePage) {
+		this.debates = debatePage.getContent().stream().map(DebateSimpleResponse::from).toList();
+		this.totalPages = debatePage.getTotalPages();
+	}
 }

--- a/src/main/java/goorm/eagle7/stelligence/domain/debate/dto/DebateResponse.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/debate/dto/DebateResponse.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import goorm.eagle7.stelligence.domain.amendment.dto.AmendmentResponse;
+import goorm.eagle7.stelligence.domain.debate.model.Debate;
 import goorm.eagle7.stelligence.domain.member.dto.MemberSimpleResponse;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -33,7 +34,28 @@ public class DebateResponse {
 	// 수정안 정보
 	private List<AmendmentResponse> amendments;
 
-	// 이전/다음 토론 정보
+	// 이전/다음 토론 정보 (추후 요구사항에 따라 추가될 예정입니다.)
 	private DebateSimpleResponse prevDebate;
 	private DebateSimpleResponse nextDebate;
+
+	public static DebateResponse of(Debate debate) {
+		return new DebateResponse(debate);
+	}
+
+	private DebateResponse(Debate debate) {
+		this.debateId = debate.getId();
+		this.createdAt = debate.getCreatedAt();
+		this.endAt = debate.getEndAt();
+
+		this.documentId = debate.getContribute().getDocument().getId();
+		this.documentTitle = debate.getContribute().getDocument().getTitle();
+
+		this.contributor = MemberSimpleResponse.from(debate.getContribute().getMember());
+
+		this.contributeId = debate.getContribute().getId();
+		this.contributeTitle = debate.getContribute().getTitle();
+		this.contributeDescription = debate.getContribute().getDescription();
+
+		this.amendments = debate.getContribute().getAmendments().stream().map(AmendmentResponse::of).toList();
+	}
 }

--- a/src/main/java/goorm/eagle7/stelligence/domain/debate/dto/DebateSimpleResponse.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/debate/dto/DebateSimpleResponse.java
@@ -2,6 +2,7 @@ package goorm.eagle7.stelligence.domain.debate.dto;
 
 import java.time.LocalDateTime;
 
+import goorm.eagle7.stelligence.domain.debate.model.Debate;
 import goorm.eagle7.stelligence.domain.member.dto.MemberSimpleResponse;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -14,12 +15,14 @@ public class DebateSimpleResponse {
 	// 토론 정보
 	private Long debateId;
 	private LocalDateTime createdAt;
+	private LocalDateTime endAt;
 
 	// 문서 정보
 	private Long documentId;
 	private String documentTitle;
 
 	// 수정요청 정보
+	private Long contributeId;
 	private String contributeTitle;
 
 	// 댓글 정보
@@ -27,4 +30,23 @@ public class DebateSimpleResponse {
 
 	// 수정요청자 정보
 	private MemberSimpleResponse contributor;
+
+	public static DebateSimpleResponse from(Debate debate) {
+		return new DebateSimpleResponse(debate);
+	}
+
+	private DebateSimpleResponse(Debate debate) {
+		this.debateId = debate.getId();
+		this.createdAt = debate.getCreatedAt();
+		this.endAt = debate.getEndAt();
+
+		this.documentId = debate.getContribute().getDocument().getId();
+		this.documentTitle = debate.getContribute().getDocument().getTitle();
+
+		this.contributeId = debate.getContribute().getId();
+		this.contributeTitle = debate.getContribute().getTitle();
+
+		this.commentsCount = debate.getComments().size();
+		this.contributor = MemberSimpleResponse.from(debate.getContribute().getMember());
+	}
 }

--- a/src/main/java/goorm/eagle7/stelligence/domain/debate/model/Debate.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/debate/model/Debate.java
@@ -1,6 +1,8 @@
 package goorm.eagle7.stelligence.domain.debate.model;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 import goorm.eagle7.stelligence.common.entity.BaseTimeEntity;
 import goorm.eagle7.stelligence.domain.contribute.model.Contribute;
@@ -14,6 +16,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -41,6 +44,9 @@ public class Debate extends BaseTimeEntity {
 
 	// 댓글의 순서를 부여하기 위한 시퀀스
 	private int commentSequence;
+
+	@OneToMany(mappedBy = "debate")
+	private List<Comment> comments = new ArrayList<>();
 
 	// 수정 요청으로부터 토론을 생성합니다.
 	private Debate(Contribute contribute) {

--- a/src/main/java/goorm/eagle7/stelligence/domain/debate/model/Debate.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/debate/model/Debate.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 
 import goorm.eagle7.stelligence.common.entity.BaseTimeEntity;
 import goorm.eagle7.stelligence.domain.contribute.model.Contribute;
+import goorm.eagle7.stelligence.domain.contribute.model.ContributeStatus;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -40,4 +41,21 @@ public class Debate extends BaseTimeEntity {
 
 	// 댓글의 순서를 부여하기 위한 시퀀스
 	private int commentSequence;
+
+	// 수정 요청으로부터 토론을 생성합니다.
+	private Debate(Contribute contribute) {
+		contribute.setStatusDebating();
+		this.contribute = contribute;
+		this.status = DebateStatus.OPEN;
+		this.endAt = LocalDateTime.now().plusDays(1L);
+		this.commentSequence = 1;
+	}
+
+	// 특정 수정 요청으로부터 토론을 개시합니다.
+	public static Debate openFrom(Contribute contribute) {
+		if (!ContributeStatus.VOTING.equals(contribute.getStatus())) {
+			throw new IllegalStateException("투표 중인 수정요청만 토론으로 전환할 수 있습니다.");
+		}
+		return new Debate(contribute);
+	}
 }

--- a/src/main/java/goorm/eagle7/stelligence/domain/debate/model/Debate.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/debate/model/Debate.java
@@ -58,4 +58,14 @@ public class Debate extends BaseTimeEntity {
 		}
 		return new Debate(contribute);
 	}
+
+	// 특정 토론을 닫습니다.
+	public void close() {
+		// 이미 종료된 토론이라면 그대로 유지
+		if (DebateStatus.CLOSED.equals(this.status)) {
+			return;
+		}
+		this.status = DebateStatus.CLOSED;
+		this.endAt = LocalDateTime.now();
+	}
 }

--- a/src/main/java/goorm/eagle7/stelligence/domain/member/dto/MemberSimpleResponse.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/member/dto/MemberSimpleResponse.java
@@ -1,5 +1,6 @@
 package goorm.eagle7.stelligence.domain.member.dto;
 
+import goorm.eagle7.stelligence.domain.member.model.Member;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -12,4 +13,8 @@ public class MemberSimpleResponse {
 	private Long memberId;
 	private String nickname;
 	private String profileImgUrl;
+
+	public static MemberSimpleResponse from(Member member) {
+		return new MemberSimpleResponse(member.getId(), member.getNickname(), member.getImageUrl());
+	}
 }

--- a/src/test/java/goorm/eagle7/stelligence/config/mockdata/TestFixtureGenerator.java
+++ b/src/test/java/goorm/eagle7/stelligence/config/mockdata/TestFixtureGenerator.java
@@ -2,6 +2,7 @@ package goorm.eagle7.stelligence.config.mockdata;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Set;
 
@@ -9,6 +10,9 @@ import goorm.eagle7.stelligence.domain.amendment.model.Amendment;
 import goorm.eagle7.stelligence.domain.amendment.model.AmendmentType;
 import goorm.eagle7.stelligence.domain.contribute.model.Contribute;
 import goorm.eagle7.stelligence.domain.contribute.model.ContributeStatus;
+import goorm.eagle7.stelligence.domain.debate.model.Comment;
+import goorm.eagle7.stelligence.domain.debate.model.Debate;
+import goorm.eagle7.stelligence.domain.debate.model.DebateStatus;
 import goorm.eagle7.stelligence.domain.document.content.model.Document;
 import goorm.eagle7.stelligence.domain.member.model.Badge;
 import goorm.eagle7.stelligence.domain.member.model.Member;
@@ -240,6 +244,80 @@ public class TestFixtureGenerator {
 			return (Contribute)contribute;
 
 		} catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	public static Debate debate(Long id, Contribute contribute, DebateStatus status, LocalDateTime endAt, int commentSequence) {
+
+		try {
+			Class<?> contributeClazz = Class.forName("goorm.eagle7.stelligence.domain.debate.model.Debate");
+
+			Constructor<?> constructor = contributeClazz.getDeclaredConstructor();
+			constructor.setAccessible(true);
+
+			Object debate = constructor.newInstance();
+
+			Field idField = contributeClazz.getDeclaredField("id");
+			Field contributeField = contributeClazz.getDeclaredField("contribute");
+			Field statusField = contributeClazz.getDeclaredField("status");
+			Field endAtField = contributeClazz.getDeclaredField("endAt");
+			Field commentSequenceField = contributeClazz.getDeclaredField("commentSequence");
+			Field commentsField = contributeClazz.getDeclaredField("comments");
+
+			idField.setAccessible(true);
+			contributeField.setAccessible(true);
+			statusField.setAccessible(true);
+			endAtField.setAccessible(true);
+			commentSequenceField.setAccessible(true);
+			commentsField.setAccessible(true);
+
+			idField.set(debate, id);
+			contributeField.set(debate, contribute);
+			statusField.set(debate, status);
+			endAtField.set(debate, endAt);
+			commentSequenceField.set(debate, commentSequence);
+			commentsField.set(debate, new ArrayList<>());
+
+			return (Debate)debate;
+
+		} catch (Exception e) {
+			e.printStackTrace();
+			throw new RuntimeException(e);
+		}
+	}
+
+	public static Comment comment(Long id, Debate debate, Member member, String content, int sequence) {
+		try {
+			Class<?> contributeClazz = Class.forName("goorm.eagle7.stelligence.domain.debate.model.Comment");
+
+			Constructor<?> constructor = contributeClazz.getDeclaredConstructor();
+			constructor.setAccessible(true);
+
+			Object comment = constructor.newInstance();
+
+			Field idField = contributeClazz.getDeclaredField("id");
+			Field debateField = contributeClazz.getDeclaredField("debate");
+			Field commenterField = contributeClazz.getDeclaredField("commenter");
+			Field contentField = contributeClazz.getDeclaredField("content");
+			Field sequenceField = contributeClazz.getDeclaredField("sequence");
+
+			idField.setAccessible(true);
+			debateField.setAccessible(true);
+			commenterField.setAccessible(true);
+			contentField.setAccessible(true);
+			sequenceField.setAccessible(true);
+
+			idField.set(comment, id);
+			debateField.set(comment, debate);
+			commenterField.set(comment, member);
+			contentField.set(comment, content);
+			sequenceField.set(comment, sequence);
+
+			return (Comment)comment;
+
+		} catch (Exception e) {
+			e.printStackTrace();
 			throw new RuntimeException(e);
 		}
 	}

--- a/src/test/java/goorm/eagle7/stelligence/domain/debate/DebateServiceTest.java
+++ b/src/test/java/goorm/eagle7/stelligence/domain/debate/DebateServiceTest.java
@@ -1,0 +1,190 @@
+package goorm.eagle7.stelligence.domain.debate;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import goorm.eagle7.stelligence.api.exception.BaseException;
+import goorm.eagle7.stelligence.config.mockdata.TestFixtureGenerator;
+import goorm.eagle7.stelligence.domain.contribute.model.Contribute;
+import goorm.eagle7.stelligence.domain.contribute.model.ContributeStatus;
+import goorm.eagle7.stelligence.domain.debate.dto.DebatePageResponse;
+import goorm.eagle7.stelligence.domain.debate.dto.DebateResponse;
+import goorm.eagle7.stelligence.domain.debate.model.Debate;
+import goorm.eagle7.stelligence.domain.debate.model.DebateStatus;
+import goorm.eagle7.stelligence.domain.document.content.model.Document;
+import goorm.eagle7.stelligence.domain.member.model.Member;
+
+@ExtendWith(MockitoExtension.class)
+class DebateServiceTest {
+
+	@Mock
+	private DebateRepository debateRepository;
+
+	@InjectMocks
+	private DebateService debateService;
+
+	@Test
+	@DisplayName("투표중인 수정요청을 토론으로 전환")
+	void convertVotingContributeToDebate() {
+		// given
+		Contribute contribute = TestFixtureGenerator.contribute(1L, null, ContributeStatus.VOTING, null);
+
+		// when
+		debateService.convertToDebate(contribute);
+
+		// then
+		// 토론은 debateRepository의 save 메서드에 의해 저장된다.
+		verify(debateRepository).save(any(Debate.class));
+		// 변환하고 나면 contribute의 상태가 토론중으로 바뀌어야한다.
+		assertThat(contribute.getStatus()).isEqualTo(ContributeStatus.DEBATING);
+	}
+
+	@Test
+	@DisplayName("투표중이 상태가 아닌 수정요청을 토론으로 전환")
+	void convertNotVotingContributeToDebate() {
+		// given
+		Contribute debatingContribute = TestFixtureGenerator.contribute(1L, null, ContributeStatus.DEBATING, null);
+		Contribute mergedContribute = TestFixtureGenerator.contribute(1L, null, ContributeStatus.MERGED, null);
+		Contribute rejectedContribute = TestFixtureGenerator.contribute(1L, null, ContributeStatus.REJECTED, null);
+
+		// when
+
+		// then
+		// 토론중인 or 병합된 or 기각된 수정요청은 토론으로 전환할 수 없다.
+		assertThatThrownBy(() -> debateService.convertToDebate(debatingContribute))
+			.isInstanceOf(IllegalStateException.class)
+			.hasMessage("투표 중인 수정요청만 토론으로 전환할 수 있습니다.");
+		assertThatThrownBy(() -> debateService.convertToDebate(mergedContribute))
+			.isInstanceOf(IllegalStateException.class)
+			.hasMessage("투표 중인 수정요청만 토론으로 전환할 수 있습니다.");
+		assertThatThrownBy(() -> debateService.convertToDebate(rejectedContribute))
+			.isInstanceOf(IllegalStateException.class)
+			.hasMessage("투표 중인 수정요청만 토론으로 전환할 수 있습니다.");
+
+		// 예외가 발생했으니 토론은 저장되지 않는다.
+		verify(debateRepository, never()).save(any(Debate.class));
+	}
+
+	@Test
+	@DisplayName("열려있던 토론 종료하기")
+	void closeOpenDebateById() {
+		// given
+		Long debateId = 1L;
+		Debate debate = TestFixtureGenerator.debate(debateId, null, DebateStatus.OPEN, null, 0);
+		when(debateRepository.findById(debateId)).thenReturn(Optional.of(debate));
+
+		// when
+		debateService.closeDebateById(debateId);
+
+		// then
+		// 변환하고 나면 debate의 상태가 닫힘으로 바뀌고 닫힌 시간이 현재 시간이 되어야한다.
+		assertThat(debate.getStatus()).isEqualTo(DebateStatus.CLOSED);
+		assertThat(debate.getEndAt()).isCloseTo(LocalDateTime.now(), within(10, ChronoUnit.SECONDS));
+		// 토론은 debateRepository의 findById 메서드에 의해 찾아와진다.
+		verify(debateRepository, times(1)).findById(debateId);
+	}
+
+	@Test
+	@DisplayName("닫혀있던 토론 종료하기")
+	void closeClosedDebateById() {
+		// given
+		Long debateId = 1L;
+		LocalDateTime endAt = LocalDateTime.now().minusDays(1L);
+		Debate debate = TestFixtureGenerator.debate(debateId, null, DebateStatus.CLOSED, endAt, 0);
+		when(debateRepository.findById(debateId)).thenReturn(Optional.of(debate));
+
+		// when
+		debateService.closeDebateById(debateId);
+
+		// then
+		// 이미 닫힌 debate는 그대로 닫힘으로 유지하고, 종료 시각은 원래 상태를 유지해야한다.
+		assertThat(debate.getStatus()).isEqualTo(DebateStatus.CLOSED);
+		assertThat(debate.getEndAt()).isEqualTo(endAt);
+		// 토론은 debateRepository의 findById 메서드에 의해 찾아와진다.
+		verify(debateRepository, times(1)).findById(debateId);
+	}
+
+	@Test
+	@DisplayName("토론 상세 조회")
+	void getDebateDetailById() {
+		// given
+		Long debateId = 1L;
+		Member author = TestFixtureGenerator.member(1L, "author1");
+		Member contributor = TestFixtureGenerator.member(1L, "contributor1");
+		Document document = TestFixtureGenerator.document(1L, author, "title1", 1L);
+		Contribute contribute = TestFixtureGenerator.contribute(1L, contributor, ContributeStatus.VOTING, document);
+		Debate debate = TestFixtureGenerator.debate(debateId, contribute, DebateStatus.OPEN, null, 0);
+
+		when(debateRepository.findByIdWithContribute(debateId)).thenReturn(Optional.of(debate));
+
+		// when
+		DebateResponse debateDetail = debateService.getDebateDetailById(debateId);
+
+		// then
+		verify(debateRepository, times(1)).findByIdWithContribute(debateId);
+	}
+
+	@Test
+	@DisplayName("존재하지 않는 토론 상세 조회")
+	void getNonExistDebateDetailById() {
+		// given
+		Long debateId = 1L;
+
+		when(debateRepository.findByIdWithContribute(debateId))
+			.thenThrow(new BaseException("존재하지 않는 토론에 대한 조회 요청입니다. Debate ID: " + debateId));
+
+		// when
+
+		// then
+		assertThatThrownBy(() -> debateService.getDebateDetailById(debateId))
+			.isInstanceOf(BaseException.class)
+			.hasMessage("존재하지 않는 토론에 대한 조회 요청입니다. Debate ID: " + debateId);
+		verify(debateRepository, times(1)).findByIdWithContribute(debateId);
+	}
+
+	@Test
+	@DisplayName("열려있는 토론 페이징 적용하여 조회")
+	void getOpenDebatePage() {
+		// given
+		Page mockPage = mock(Page.class);
+		Pageable pageable = mock(Pageable.class);
+		when(debateRepository.findPageByStatus(DebateStatus.OPEN, pageable)).thenReturn(mockPage);
+		
+		// when
+		DebatePageResponse debatePage = debateService.getDebatePage(DebateStatus.OPEN, pageable);
+
+		// then
+		verify(debateRepository, times(1)).findPageByStatus(DebateStatus.OPEN, pageable);
+		verify(debateRepository, never()).findPageByStatus(DebateStatus.CLOSED, pageable);
+	}
+
+	@Test
+	@DisplayName("닫혀있는 토론 페이징 적용하여 조회")
+	void getClosedDebatePage() {
+		// given
+		Page mockPage = mock(Page.class);
+		Pageable pageable = mock(Pageable.class);
+		when(debateRepository.findPageByStatus(DebateStatus.CLOSED, pageable)).thenReturn(mockPage);
+
+		// when
+		DebatePageResponse debatePage = debateService.getDebatePage(DebateStatus.CLOSED, pageable);
+
+		// then
+		verify(debateRepository, times(1)).findPageByStatus(DebateStatus.CLOSED, pageable);
+		verify(debateRepository, never()).findPageByStatus(DebateStatus.OPEN, pageable);
+	}
+
+}


### PR DESCRIPTION
## 변경 내용 

- 토론 서비스 로직을 개발하였습니다.
  - 수정요청을 토론으로 전환할 수 있습니다.
  - 토론을 닫을 수 있습니다.
  - 토론을 단건 조회할 수 있습니다.
  - 토론 리스트를 페이징을 적용하여 조회할 수 있습니다.

## 특이 사항

- 토론으로 전환하는 로직과 토론을 종료하는 로직은 추후에 서비스 계층이 아닌 스케쥴러에서 직접 수행하는 것으로 이동될 수 있습니다.
- [@Sooamazing] MemberSimpleResponse에서 Member를 받는 정적 팩토리 메서드를 만들었습니다.
- 토론 테스트의 `void closeOpenDebateById()`에서 토론이 종료되었을때 `endAt`이 정상적으로 업데이트 되었는지를 아래와 같이 업데이트된 `endAt`이 현재 시간과 10초 이상 차이나지 않는지를 확인하고 있습니다. 더 괜찮은 방식이 있다면 피드백 부탁드립니다.
  - `assertThat(debate.getEndAt()).isCloseTo(LocalDateTime.now(), within(10, ChronoUnit.SECONDS));`

## 체크리스트

- [x] PR 날리기 전에 main branch pull 받으셨나요?
- [x] application.properties 등 노출되지 않아야 하는 파일이 올라가지는 않았나요?
- [x] 다른 담당자 파일을 수정한 부분에 대해서 이야기 하셨나요?
- [x] 주석 "상세히" 다셨나요?
- [x] 제출하기 전에 테스트코드 돌려 보셨나요?

closes #
