### PR TITLE
153 Image Controller 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,9 @@ dependencies {
     // https://mvnrepository.com/artifact/com.googlecode.owasp-java-html-sanitizer/owasp-java-html-sanitizer
     implementation 'com.googlecode.owasp-java-html-sanitizer:owasp-java-html-sanitizer:20220608.1'
 
+    //s3 sdk
+    implementation 'software.amazon.awssdk:s3:2.17.0'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/goorm/eagle7/stelligence/common/image/ImageUploadController.java
+++ b/src/main/java/goorm/eagle7/stelligence/common/image/ImageUploadController.java
@@ -10,6 +10,9 @@ import org.springframework.web.bind.annotation.RestController;
 
 import goorm.eagle7.stelligence.api.ResponseTemplate;
 import goorm.eagle7.stelligence.api.exception.BaseException;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -27,6 +30,7 @@ import software.amazon.awssdk.services.s3.model.PutObjectRequest;
  * <p>어떠한 섹션에도 포함되지 않는 고아 이미지가 존재할 수 있습니다.
  * 불필요한 이미지를 청소하는 방법은 추후 고민해봐야 할 것 같습니다.
  */
+@Tag(name = "이미지 업로드", description = "이미지 파일을 업로드합니다.")
 @Slf4j
 @RestController
 @RequiredArgsConstructor
@@ -44,6 +48,17 @@ public class ImageUploadController {
 
 	private final S3Client s3Client;
 
+	@Operation(
+		summary = "이미지 업로드",
+		description = "이미지를 업로드 합니다.  "
+			+ "이미지 파일은 PNG, JPEG, GIF 형식만 업로드할 수 있으며, " + MAX_IMAGE_MB + "MB 이하만 업로드할 수 있습니다. "
+			+ "업로드된 이미지의 URL을 반환합니다. "
+			+ "Content-Type: image/jpeg, image/png, image/gif 만 지원합니다.")
+	@ApiResponse(
+		responseCode = "200",
+		description = "이미지 업로드 성공",
+		useReturnTypeSchema = true
+	)
 	@PostMapping("/api/images/upload")
 	public ResponseTemplate<String> uploadImage(HttpServletRequest request) {
 

--- a/src/main/java/goorm/eagle7/stelligence/common/image/ImageUploadController.java
+++ b/src/main/java/goorm/eagle7/stelligence/common/image/ImageUploadController.java
@@ -1,0 +1,95 @@
+package goorm.eagle7.stelligence.common.image;
+
+import java.io.IOException;
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import goorm.eagle7.stelligence.api.ResponseTemplate;
+import goorm.eagle7.stelligence.api.exception.BaseException;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+/**
+ * 이미지 업로드 컨트롤러
+ *
+ * <p>PNG, JPEG, GIF 이미지 파일만 업로드할 수 있습니다.
+ *
+ * <p>이미지 파일은 5MB 이하만 업로드할 수 있습니다.
+ *
+ * <p>어떠한 섹션에도 포함되지 않는 고아 이미지가 존재할 수 있습니다.
+ * 불필요한 이미지를 청소하는 방법은 추후 고민해봐야 할 것 같습니다.
+ */
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class ImageUploadController {
+
+	@Value("${aws.s3.bucketName}")
+	private String bucketName;
+
+	@Value("${aws.s3.bucketUrl}")
+	private String bucketUrl;
+
+	private static final long MAX_IMAGE_MB = 1; // 1MB 이하만 업로드 가능
+
+	private static final long MAX_IMAGE_BYTE = MAX_IMAGE_MB * 1024 * 1024;
+
+	private final S3Client s3Client;
+
+	@PostMapping("/api/images/upload")
+	public ResponseTemplate<String> uploadImage(HttpServletRequest request) {
+
+		// 이미지 파일인지 확인
+		String contentType = request.getContentType();
+		if (!isValidImageContentType(contentType)) {
+			throw new BaseException("이미지 파일만 업로드할 수 있습니다.");
+		}
+
+		// 이미지 파일 크기 확인
+		long contentLength = Long.parseLong(request.getHeader("Content-Length"));
+		if (contentLength > MAX_IMAGE_BYTE) {
+			throw new BaseException("이미지 파일은 " + MAX_IMAGE_MB + "MB 이하만 업로드할 수 있습니다.");
+		}
+
+		// 이미지 업로드 - Stream 방식
+		try {
+			String fileName = UUID.randomUUID().toString();
+			s3Client.putObject(
+				PutObjectRequest.builder()
+					.bucket(bucketName)
+					.key(fileName)
+					.contentType(contentType)
+					.build(),
+				RequestBody.fromInputStream(request.getInputStream(), contentLength)
+			);
+
+			// 이미지 업로드 성공
+			return ResponseTemplate.ok(bucketUrl + fileName);
+
+		} catch (IOException e) {
+			log.error("이미지 업로드에 실패했습니다.", e);
+			throw new BaseException("이미지 업로드에 실패했습니다.");
+		}
+
+	}
+
+	/**
+	 * 이미지 파일인지 확인
+	 * @param contentType 컨텐츠 타입
+	 * @return 이미지 파일이면 true
+	 */
+	private boolean isValidImageContentType(String contentType) {
+		return contentType.equals(MediaType.IMAGE_JPEG_VALUE)
+			|| contentType.equals(MediaType.IMAGE_PNG_VALUE)
+			|| contentType.equals(MediaType.IMAGE_GIF_VALUE);
+	}
+
+}

--- a/src/main/java/goorm/eagle7/stelligence/config/S3Config.java
+++ b/src/main/java/goorm/eagle7/stelligence/config/S3Config.java
@@ -1,0 +1,30 @@
+package goorm.eagle7.stelligence.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+@PropertySource("classpath:aws.properties")
+public class S3Config {
+
+	@Value("${aws.s3.accessKey}")
+	private String accessKey;
+
+	@Value("${aws.s3.secretKey}")
+	private String secretKey;
+
+	@Bean
+	public S3Client s3Client() {
+		return S3Client.builder()
+			.credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey, secretKey)))
+			.region(Region.AP_NORTHEAST_2)
+			.build();
+	}
+}


### PR DESCRIPTION
## 변경 내용 

- /api/images/upload를 통해 사용자는 이미지 바이너리 데이터를 서버로 전송하고, 해당 이미지를 볼 수 있는 url을 응답으로 확인할 수 있습니다.
- 5MB 이하의 파일만 받을 수 있으며, 이는 컨트롤러의 정적 변수를 통해 변경 가능합니다.
-  IMG 형식만 받습니다.
# 특이사항

- aws.properties를 추가하여야 정상적으로 동작합니다. 이 내용은 슬랙을 통해 전달하겠습니다.
@eenzzi  @youngandmini  @Sooamazing 


## 체크리스트

- [x] PR 날리기 전에 main branch pull 받으셨나요?
- [x] application.properties 등 노출되지 않아야 하는 파일이 올라가지는 않았나요?
- [x] 다른 담당자 파일을 수정한 부분에 대해서 이야기 하셨나요?
- [x] 주석 "상세히" 다셨나요?
- [x] 제출하기 전에 테스트코드 돌려 보셨나요?

closes #153 
