### PR TITLE
[#169] refactor: DebateResponse에 토론 종료 여부 추가

### DIFF
--- a/src/main/java/goorm/eagle7/stelligence/domain/debate/dto/DebateResponse.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/debate/dto/DebateResponse.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import goorm.eagle7.stelligence.domain.amendment.dto.AmendmentResponse;
 import goorm.eagle7.stelligence.domain.debate.model.Debate;
+import goorm.eagle7.stelligence.domain.debate.model.DebateStatus;
 import goorm.eagle7.stelligence.domain.member.dto.MemberSimpleResponse;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -18,6 +19,7 @@ public class DebateResponse {
 	private Long debateId;
 	private LocalDateTime createdAt;
 	private LocalDateTime endAt;
+	private DebateStatus status;
 
 	// 문서 정보
 	private Long documentId;
@@ -46,6 +48,7 @@ public class DebateResponse {
 		this.debateId = debate.getId();
 		this.createdAt = debate.getCreatedAt();
 		this.endAt = debate.getEndAt();
+		this.status = debate.getStatus();
 
 		this.documentId = debate.getContribute().getDocument().getId();
 		this.documentTitle = debate.getContribute().getDocument().getTitle();


### PR DESCRIPTION
## 변경 내용 

- DebateResponse의 필드에 토론 종료 여부를 추가하였습니다.

## 특이 사항

- 없습니다

## 체크리스트

- [x] PR 날리기 전에 main branch pull 받으셨나요?
- [x] application.properties 등 노출되지 않아야 하는 파일이 올라가지는 않았나요?
- [x] 다른 담당자 파일을 수정한 부분에 대해서 이야기 하셨나요?
- [x] 주석 "상세히" 다셨나요?
- [x] 제출하기 전에 테스트코드 돌려 보셨나요?

closes #
