### PR TITLE
171 Document Content 반환 타입 대대적인 수정

### DIFF
--- a/src/main/java/goorm/eagle7/stelligence/domain/debate/repository/DebateRepository.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/debate/repository/DebateRepository.java
@@ -11,6 +11,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import goorm.eagle7.stelligence.domain.debate.model.Debate;
+import goorm.eagle7.stelligence.domain.debate.model.DebateStatus;
 import jakarta.persistence.LockModeType;
 
 public interface DebateRepository extends JpaRepository<Debate, Long>, CustomDebateRepository {
@@ -21,7 +22,6 @@ public interface DebateRepository extends JpaRepository<Debate, Long>, CustomDeb
 		+ " join fetch c.amendments a"
 		+ " where d.id = :debateId")
 	Optional<Debate> findByIdWithContribute(@Param("debateId") Long debateId);
-
 
 	/**
 	 * 토론의 sequence를 이용해 다음 댓글의 sequence를 얻기 위해 조회합니다.
@@ -54,5 +54,13 @@ public interface DebateRepository extends JpaRepository<Debate, Long>, CustomDeb
 		+ " where d.status = goorm.eagle7.stelligence.domain.debate.model.DebateStatus.OPEN"
 		+ " and d.endAt <= :now")
 	List<Long> findOpenDebateIdByEndAt(@Param("now") LocalDateTime now);
+
+	/**
+	 * Document에 대하여 특정한 상태의 토론이 존재하는지 확인합니다.
+	 * @param documentId : 조회하려는 Document의 ID
+	 * @param status : 조회하려는 토론의 상태
+	 * @return boolean : 토론이 존재하면 true, 존재하지 않으면 false를 반환합니다.
+	 */
+	boolean existsByContributeDocumentIdAndStatus(Long documentId, DebateStatus status);
 
 }

--- a/src/main/java/goorm/eagle7/stelligence/domain/document/DocumentService.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/document/DocumentService.java
@@ -68,7 +68,7 @@ public class DocumentService {
 		 * 추후에 코드가 변경될 여지가 있습니다. 자세한 내용은 Document.sections의 주석을 참고해주세요.
 		 */
 		List<SectionResponse> sections = createdDocument.getSections().stream().map(SectionResponse::of).toList();
-		return DocumentResponse.of(createdDocument, sections, Collections.emptyList());
+		return DocumentResponse.of(createdDocument, sections, Collections.emptyList(), true);
 	}
 
 	/**

--- a/src/main/java/goorm/eagle7/stelligence/domain/document/content/DocumentContentService.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/document/content/DocumentContentService.java
@@ -8,6 +8,10 @@ import org.springframework.transaction.annotation.Transactional;
 
 import goorm.eagle7.stelligence.api.exception.BaseException;
 import goorm.eagle7.stelligence.common.sequence.SectionIdGenerator;
+import goorm.eagle7.stelligence.domain.contribute.ContributeRepository;
+import goorm.eagle7.stelligence.domain.contribute.model.ContributeStatus;
+import goorm.eagle7.stelligence.domain.debate.model.DebateStatus;
+import goorm.eagle7.stelligence.domain.debate.repository.DebateRepository;
 import goorm.eagle7.stelligence.domain.document.content.dto.DocumentResponse;
 import goorm.eagle7.stelligence.domain.document.content.dto.SectionRequest;
 import goorm.eagle7.stelligence.domain.document.content.dto.SectionResponse;
@@ -35,6 +39,8 @@ public class DocumentContentService {
 	private final SectionRepository sectionRepository;
 	private final SectionIdGenerator sectionIdGenerator;
 	private final DocumentParser documentParser;
+	private final ContributeRepository contributeRepository;
+	private final DebateRepository debateRepository;
 
 	/**
 	 * Document를 생성합니다.
@@ -109,7 +115,13 @@ public class DocumentContentService {
 			.map(MemberSimpleResponse::from)
 			.toList();
 
-		return DocumentResponse.of(document, sections, contributors);
+		// 수정 가능 여부를 판별
+		// 정확히는 토론 종료 후 1일 동안은 기본적으로 불가능하며, 토론자에게만 수정요청을 받을 수 있도록 만들어야 합니다.
+		boolean isVoting = contributeRepository.existsByDocumentAndStatus(document, ContributeStatus.VOTING);
+		boolean isDebating = debateRepository.existsByContributeDocumentIdAndStatus(documentId, DebateStatus.OPEN);
+		boolean isEditable = !isVoting && !isDebating;
+
+		return DocumentResponse.of(document, sections, contributors, isEditable);
 	}
 
 	/**

--- a/src/main/java/goorm/eagle7/stelligence/domain/document/content/DocumentContentService.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/document/content/DocumentContentService.java
@@ -13,7 +13,7 @@ import goorm.eagle7.stelligence.domain.document.content.dto.SectionRequest;
 import goorm.eagle7.stelligence.domain.document.content.dto.SectionResponse;
 import goorm.eagle7.stelligence.domain.document.content.model.Document;
 import goorm.eagle7.stelligence.domain.document.content.parser.DocumentParser;
-import goorm.eagle7.stelligence.domain.member.dto.MemberDetailResponse;
+import goorm.eagle7.stelligence.domain.member.dto.MemberSimpleResponse;
 import goorm.eagle7.stelligence.domain.member.model.Member;
 import goorm.eagle7.stelligence.domain.section.SectionRepository;
 import goorm.eagle7.stelligence.domain.section.model.Section;
@@ -104,9 +104,9 @@ public class DocumentContentService {
 			.toList();
 
 		//해당 문서의 기여자들을 조회합니다.
-		List<MemberDetailResponse> contributors = documentRepository.findContributorsByDocumentId(documentId)
+		List<MemberSimpleResponse> contributors = documentRepository.findContributorsByDocumentId(documentId)
 			.stream()
-			.map(MemberDetailResponse::from)
+			.map(MemberSimpleResponse::from)
 			.toList();
 
 		return DocumentResponse.of(document, sections, contributors);

--- a/src/main/java/goorm/eagle7/stelligence/domain/document/content/dto/DocumentResponse.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/document/content/dto/DocumentResponse.java
@@ -43,6 +43,12 @@ public class DocumentResponse {
 	private List<MemberSimpleResponse> contributors;
 
 	/**
+	 * 사용자가 글을 수정할 수 있는지 여부입니다.
+	 * 투표 중 혹은 토론 종료 1일 전까지는 수정이 제한됩니다.
+	 */
+	private boolean isEditable;
+
+	/**
 	 * DocumentResponse를 생성합니다.
 	 *
 	 * DocumentResponse의 sections는 해당 Document와 연결된 모든 Section을 담지 않습니다.
@@ -54,7 +60,8 @@ public class DocumentResponse {
 	public static DocumentResponse of(
 		Document document,
 		List<SectionResponse> sections,
-		List<MemberSimpleResponse> contributors
+		List<MemberSimpleResponse> contributors,
+		boolean isEditable
 	) {
 		return new DocumentResponse(
 			document.getId(),
@@ -63,7 +70,8 @@ public class DocumentResponse {
 			sections,
 			SectionResponseConcatenator.concat(sections),
 			MemberSimpleResponse.from(document.getAuthor()),
-			contributors
+			contributors,
+			isEditable
 		);
 	}
 

--- a/src/main/java/goorm/eagle7/stelligence/domain/document/content/dto/DocumentResponse.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/document/content/dto/DocumentResponse.java
@@ -1,5 +1,6 @@
 package goorm.eagle7.stelligence.domain.document.content.dto;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import goorm.eagle7.stelligence.domain.document.content.model.Document;
@@ -21,6 +22,10 @@ public class DocumentResponse {
 
 	private Long documentId;
 	private String title;
+
+	// 최종 수정 일시
+	private LocalDateTime lastModifiedAt;
+
 	private List<SectionResponse> sections;
 
 	/**
@@ -54,6 +59,7 @@ public class DocumentResponse {
 		return new DocumentResponse(
 			document.getId(),
 			document.getTitle(),
+			document.getUpdatedAt(),
 			sections,
 			SectionResponseConcatenator.concat(sections),
 			MemberDetailResponse.from(document.getAuthor()),

--- a/src/main/java/goorm/eagle7/stelligence/domain/document/content/dto/DocumentResponse.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/document/content/dto/DocumentResponse.java
@@ -5,7 +5,7 @@ import java.util.List;
 
 import goorm.eagle7.stelligence.domain.document.content.model.Document;
 import goorm.eagle7.stelligence.domain.document.content.parser.SectionResponseConcatenator;
-import goorm.eagle7.stelligence.domain.member.dto.MemberDetailResponse;
+import goorm.eagle7.stelligence.domain.member.dto.MemberSimpleResponse;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -38,9 +38,9 @@ public class DocumentResponse {
 	private String content;
 
 	// 최초 기여자
-	private MemberDetailResponse originalAuthor;
+	private MemberSimpleResponse originalAuthor;
 
-	private List<MemberDetailResponse> contributors;
+	private List<MemberSimpleResponse> contributors;
 
 	/**
 	 * DocumentResponse를 생성합니다.
@@ -54,7 +54,7 @@ public class DocumentResponse {
 	public static DocumentResponse of(
 		Document document,
 		List<SectionResponse> sections,
-		List<MemberDetailResponse> contributors
+		List<MemberSimpleResponse> contributors
 	) {
 		return new DocumentResponse(
 			document.getId(),
@@ -62,7 +62,7 @@ public class DocumentResponse {
 			document.getUpdatedAt(),
 			sections,
 			SectionResponseConcatenator.concat(sections),
-			MemberDetailResponse.from(document.getAuthor()),
+			MemberSimpleResponse.from(document.getAuthor()),
 			contributors
 		);
 	}

--- a/src/main/java/goorm/eagle7/stelligence/domain/section/model/Section.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/section/model/Section.java
@@ -12,7 +12,6 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import jakarta.persistence.IdClass;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.Lob;
 import jakarta.persistence.ManyToOne;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -34,8 +33,6 @@ public class Section extends BaseTimeEntity implements Comparable<Section> {
 	@Id
 	private Long revision;
 
-	//Member
-
 	//Document
 	@ManyToOne(fetch = LAZY)
 	@JoinColumn(name = "document_id")
@@ -46,7 +43,7 @@ public class Section extends BaseTimeEntity implements Comparable<Section> {
 
 	private String title;
 
-	@Lob
+	@Column(columnDefinition = "TEXT")
 	private String content;
 
 	@Column(name = "orders")

--- a/src/test/java/goorm/eagle7/stelligence/domain/debate/repository/DebateRepositoryTest.java
+++ b/src/test/java/goorm/eagle7/stelligence/domain/debate/repository/DebateRepositoryTest.java
@@ -121,4 +121,21 @@ class DebateRepositoryTest {
 			.allMatch(d -> d.getStatus().equals(DebateStatus.CLOSED));
 	}
 
+	@Test
+	@DisplayName("Document에 대한 특정 상태의 토론이 존재하는지 확인")
+	void existsByContributeDocumentIdAndStatus() {
+
+		// when
+		boolean res1 = debateRepository.existsByContributeDocumentIdAndStatus(1L, DebateStatus.OPEN);
+		boolean res2 = debateRepository.existsByContributeDocumentIdAndStatus(2L, DebateStatus.OPEN);
+		boolean res3 = debateRepository.existsByContributeDocumentIdAndStatus(3L, DebateStatus.OPEN);
+		boolean res4 = debateRepository.existsByContributeDocumentIdAndStatus(4L, DebateStatus.OPEN);
+
+		// then
+		assertThat(res1).isTrue();
+		assertThat(res2).isTrue();
+		assertThat(res3).isFalse();
+		assertThat(res4).isFalse();
+	}
+
 }

--- a/src/test/java/goorm/eagle7/stelligence/domain/document/content/DocumentContentServiceReadUnitTest.java
+++ b/src/test/java/goorm/eagle7/stelligence/domain/document/content/DocumentContentServiceReadUnitTest.java
@@ -114,6 +114,8 @@ class DocumentContentServiceReadUnitTest {
 		assertThat(documentResponse.getSections().get(0).getSectionId()).isEqualTo(1L); //order 1
 		assertThat(documentResponse.getSections().get(1).getSectionId()).isEqualTo(3L); //order 2
 		assertThat(documentResponse.getSections().get(2).getSectionId()).isEqualTo(2L); //order 3
+
+		assertThat(documentResponse.isEditable()).isTrue();
 	}
 
 	@Test

--- a/src/test/java/goorm/eagle7/stelligence/domain/document/content/DocumentContentServiceReadUnitTest.java
+++ b/src/test/java/goorm/eagle7/stelligence/domain/document/content/DocumentContentServiceReadUnitTest.java
@@ -15,6 +15,10 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import goorm.eagle7.stelligence.api.exception.BaseException;
+import goorm.eagle7.stelligence.domain.contribute.ContributeRepository;
+import goorm.eagle7.stelligence.domain.contribute.model.ContributeStatus;
+import goorm.eagle7.stelligence.domain.debate.model.DebateStatus;
+import goorm.eagle7.stelligence.domain.debate.repository.DebateRepository;
 import goorm.eagle7.stelligence.domain.document.content.dto.DocumentResponse;
 import goorm.eagle7.stelligence.domain.document.content.model.Document;
 import goorm.eagle7.stelligence.domain.section.SectionRepository;
@@ -29,6 +33,12 @@ class DocumentContentServiceReadUnitTest {
 
 	@Mock
 	SectionRepository sectionRepository;
+
+	@Mock
+	ContributeRepository contributeRepository;
+
+	@Mock
+	DebateRepository debateRepository;
 
 	@InjectMocks
 	DocumentContentService documentContentService;
@@ -80,13 +90,19 @@ class DocumentContentServiceReadUnitTest {
 		Section s2 = section(2L, 2L, document, Heading.H2, "title3", "content3", 3);
 		Section s3 = section(3L, 3L, document, Heading.H3, "title2", "content2", 2);
 
+		//when
 		when(documentContentRepository.findById(1L))
 			.thenReturn(Optional.of(document));
 
 		when(sectionRepository.findByVersion(document, 3L))
 			.thenReturn(List.of(s1, s2, s3));
 
-		//when
+		//토론이 진행중이지 않은 상태
+		when(debateRepository.existsByContributeDocumentIdAndStatus(1L, DebateStatus.OPEN)).thenReturn(false);
+
+		//투표중이지 않은 상태
+		when(contributeRepository.existsByDocumentAndStatus(document, ContributeStatus.VOTING)).thenReturn(false);
+
 		DocumentResponse documentResponse = documentContentService.getDocument(1L, 3L);
 
 		//assert
@@ -140,7 +156,59 @@ class DocumentContentServiceReadUnitTest {
 		//when
 		List<Long> documentIds = documentContentService.findDocumentWhichContainsKeyword("keyword");
 		//then
-		assertThat(documentIds).hasSize(3);
-		assertThat(documentIds).containsExactly(1L, 2L, 3L);
+		assertThat(documentIds).hasSize(3).containsExactly(1L, 2L, 3L);
 	}
+
+	@Test
+	@DisplayName("문서 조회 - 수정 불가능 - 토론 진행중")
+	void editableTestDebatesOpen() {
+
+		//given
+		Document document = document(1L, member(1L, "hello"), "title11", 1L);
+
+		Section s1 = section(1L, 1L, document, Heading.H1, "title1", "content1", 1);
+
+		//when
+		when(documentContentRepository.findById(1L)).thenReturn(Optional.of(document));
+
+		when(sectionRepository.findByVersion(document, 1L)).thenReturn(List.of(s1));
+
+		//토론이 진행중인 상태
+		when(debateRepository.existsByContributeDocumentIdAndStatus(1L, DebateStatus.OPEN)).thenReturn(true);
+
+		//투표중이지 않은 상태
+		when(contributeRepository.existsByDocumentAndStatus(document, ContributeStatus.VOTING)).thenReturn(false);
+
+		DocumentResponse documentResponse = documentContentService.getDocument(1L);
+
+		//then
+		assertThat(documentResponse.isEditable()).isFalse();
+	}
+
+	@Test
+	@DisplayName("문서 조회 - 수정 불가능 - 투표 진행중")
+	void editableTestVoting() {
+
+		//given
+		Document document = document(1L, member(1L, "hello"), "title11", 1L);
+
+		Section s1 = section(1L, 1L, document, Heading.H1, "title1", "content1", 1);
+
+		//when
+		when(documentContentRepository.findById(1L)).thenReturn(Optional.of(document));
+
+		when(sectionRepository.findByVersion(document, 1L)).thenReturn(List.of(s1));
+
+		//토론이 진행중이지 않음
+		when(debateRepository.existsByContributeDocumentIdAndStatus(1L, DebateStatus.OPEN)).thenReturn(false);
+
+		//투표중인 상태
+		when(contributeRepository.existsByDocumentAndStatus(document, ContributeStatus.VOTING)).thenReturn(true);
+
+		DocumentResponse documentResponse = documentContentService.getDocument(1L);
+
+		//then
+		assertThat(documentResponse.isEditable()).isFalse();
+	}
+
 }


### PR DESCRIPTION
## 변경 내용 

- 이제는 DocumentResponse에 최종수정일시 가 포함됩니다.
- 이제는 DocumentResponse에 '수정 가능 여부' 가 포함됩니다.
  - 수정 가능 여부는 토론이 진행중인지와 투표가 진행중인지에 대한 여부로, 둘다 진행중이 아닌경우에만 true로 표현됩니다.
- DocumentResposne의 유저 표현이 MemberDetailResposne에서 MemberSimpleResposne로 바뀌었습니다.
- Section.content의 데이터타입이 TEXT로 바뀌었습니다.

## 특이사항
- @youngandmini DebateRepository에 메서드 추가하고 테스트코드 작성했습니다.

## 체크리스트

- [x] PR 날리기 전에 main branch pull 받으셨나요?
- [x] application.properties 등 노출되지 않아야 하는 파일이 올라가지는 않았나요?
- [x] 다른 담당자 파일을 수정한 부분에 대해서 이야기 하셨나요?
- [x] 주석 "상세히" 다셨나요?
- [x] 제출하기 전에 테스트코드 돌려 보셨나요?

closes #171 
