### PR TITLE
[#141] bug: Set-Cookie는 보이나 쿠키가 가지 않는 문제 생겨 수정.

### DIFF
--- a/src/main/java/goorm/eagle7/stelligence/common/login/CookieUtils.java
+++ b/src/main/java/goorm/eagle7/stelligence/common/login/CookieUtils.java
@@ -112,10 +112,10 @@ public class CookieUtils {
 		ResponseCookie responseCookie = ResponseCookie.from(name, value)
 			.httpOnly(cookieHttpOnly) // XSS 방지
 			.maxAge(maxAge) //
-			.domain(cookieDomain)
+			// .domain(cookieDomain)
 			.path(cookiePath)
-			.sameSite(cookieSameSite) // CSRF 방지
-			.secure(cookieSecure) // HTTPS
+			// .sameSite(cookieSameSite) // CSRF 방지
+			// .secure(cookieSecure) // HTTPS
 			.build();
 
 		response.addHeader(headerName, responseCookie.toString());
@@ -150,10 +150,10 @@ public class CookieUtils {
 		ResponseCookie responseCookie = ResponseCookie.from(cookieName, "")
 			.httpOnly(cookieHttpOnly) // XSS 방지
 			.maxAge(0)
-			.domain(cookieDomain)
+			// .domain(cookieDomain)
 			.path(cookiePath)
-			.sameSite(cookieSameSite) // CSRF 방지
-			.secure(cookieSecure) // HTTPS
+			// .sameSite(cookieSameSite) // CSRF 방지
+			// .secure(cookieSecure) // HTTPS
 			.build();
 
 		response.addHeader(headerName, responseCookie.toString());


### PR DESCRIPTION
## 변경 내용 
- domain, sameSite, secure 설정 제거
- 이걸 한다고 되는지는 모르겠으나 현재 프론트 페이지에서 소셜 로그인 버튼 세 개는 {server}:8080/oauth2 ~~~ 로 연결, 다른 건 다 {server}/api/어쩌구~~ 이거인데, server 주소에서 요청 보내는 건 헤더 Set-Cookie 설정은 되지만, 쿠키가 안 오는 상황
- 메인과 로그인스페샬과 설정이 다른 건 해당 3개 설정이라 우선 제거 후 상황 파악 예정.

## 특이 사항
- 안 되면... 되게 하라....

## 체크리스트

- [X] PR 날리기 전에 main branch pull 받으셨나요?
- [X] application.properties 등 노출되지 않아야 하는 파일이 올라가지는 않았나요?
- [X] 다른 담당자 파일을 수정한 부분에 대해서 이야기 하셨나요?
- [X] 주석 "상세히" 다셨나요?
- [X] 제출하기 전에 테스트코드 돌려 보셨나요?

closes #141
