### PR TITLE
181 HTML Sanitizer img 태그 허용

### DIFF
--- a/src/main/java/goorm/eagle7/stelligence/config/HtmlPolicyConfig.java
+++ b/src/main/java/goorm/eagle7/stelligence/config/HtmlPolicyConfig.java
@@ -19,6 +19,8 @@ public class HtmlPolicyConfig {
 			.allowUrlProtocols("http", "https") // URL로 들어오는 값들에 대해 허용할 프로토콜 지정
 			.allowCommonBlockElements() //"p", "div", "h1", "h2", "h3", "h4", "h5", "h6", "ul", "ol", "li", "blockquote",
 			.allowCommonInlineFormattingElements() //"b", "i", "em", "strong", "a", "br", "img", "span", "hr", "code", "pre"
+			.allowElements("img")
+			.allowAttributes("src", "alt").onElements("img")
 			.toFactory();
 	}
 }

--- a/src/test/java/goorm/eagle7/stelligence/config/HtmlPolicyConfigTest.java
+++ b/src/test/java/goorm/eagle7/stelligence/config/HtmlPolicyConfigTest.java
@@ -1,0 +1,40 @@
+package goorm.eagle7.stelligence.config;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.owasp.html.PolicyFactory;
+
+/**
+ * Config 클래스이지만, 이곳에서 생성되는 빈에 대해 테스트할 위치가 마땅치 않아 이곳에서 수행합니다.
+ */
+class HtmlPolicyConfigTest {
+
+	HtmlPolicyConfig htmlPolicyConfig = new HtmlPolicyConfig();
+	PolicyFactory policyFactory = htmlPolicyConfig.htmlPolicyBuilder();
+
+	@Test
+	void noSanitizeForNormalImgTag() {
+		//given
+		String rawContent = "<h1>title</h1><img src=\"http://example.com/image.jpg\"/>";
+
+		//when
+		String sanitizedContent = policyFactory.sanitize(rawContent);
+
+		//then
+		assertThat(sanitizedContent).isEqualTo("<h1>title</h1><img src=\"http://example.com/image.jpg\" />");
+	}
+
+	@Test
+	void sanitizeImgWithScript() {
+		//given
+		String rawContent = "<p>hello</p><img src=\"javascript:악의적인코드()\"/>";
+
+		//when
+		String sanitizedContent = policyFactory.sanitize(rawContent);
+
+		//then
+		assertThat(sanitizedContent).isEqualTo("<p>hello</p>");
+	}
+
+}


### PR DESCRIPTION
## 변경 내용 

- 이제 img 태그가 글에 포함될 수 있습니다.

## 특이 사항

- 

## 체크리스트

- [x] PR 날리기 전에 main branch pull 받으셨나요?
- [x] application.properties 등 노출되지 않아야 하는 파일이 올라가지는 않았나요?
- [x] 다른 담당자 파일을 수정한 부분에 대해서 이야기 하셨나요?
- [x] 주석 "상세히" 다셨나요?
- [x] 제출하기 전에 테스트코드 돌려 보셨나요?

closes #181 
