### PR TITLE
191 document entity saves parentdocument

### DIFF
--- a/src/main/java/goorm/eagle7/stelligence/domain/contribute/ContributeRequestValidator.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/contribute/ContributeRequestValidator.java
@@ -47,6 +47,12 @@ public class ContributeRequestValidator {
 	 */
 	@Transactional(readOnly = true)
 	public void validate(ContributeRequest request) {
+
+		//수정하려는 제목이 null이나 빈값이 아닌가?
+		if (!StringUtils.hasText(request.getAfterDocumentTitle())) {
+			throw new BaseException("수정하려는 제목이 비어있습니다.");
+		}
+
 		//document가 존재하는가
 		Document document = documentContentRepository.findById(request.getDocumentId())
 			.orElseThrow(() -> new BaseException("문서가 존재하지 않습니다. documentId=" + request.getDocumentId()));
@@ -90,11 +96,6 @@ public class ContributeRequestValidator {
 			if (!isSequential(orders)) {
 				throw new BaseException("생성 순서가 순차적이지 않습니다.");
 			}
-		}
-
-		//수정하려는 제목이 null이나 빈값이 아닌가?
-		if (!StringUtils.hasText(request.getAfterDocumentTitle())) {
-			throw new BaseException("수정하려는 제목이 비어있습니다.");
 		}
 	}
 

--- a/src/main/java/goorm/eagle7/stelligence/domain/contribute/ContributeRequestValidator.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/contribute/ContributeRequestValidator.java
@@ -9,6 +9,7 @@ import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 import goorm.eagle7.stelligence.api.exception.BaseException;
 import goorm.eagle7.stelligence.domain.amendment.dto.AmendmentRequest;
@@ -89,6 +90,11 @@ public class ContributeRequestValidator {
 			if (!isSequential(orders)) {
 				throw new BaseException("생성 순서가 순차적이지 않습니다.");
 			}
+		}
+
+		//수정하려는 제목이 null이나 빈값이 아닌가?
+		if (!StringUtils.hasText(request.getNewDocumentTitle())) {
+			throw new BaseException("수정하려는 제목이 비어있습니다.");
 		}
 	}
 

--- a/src/main/java/goorm/eagle7/stelligence/domain/contribute/ContributeRequestValidator.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/contribute/ContributeRequestValidator.java
@@ -93,7 +93,7 @@ public class ContributeRequestValidator {
 		}
 
 		//수정하려는 제목이 null이나 빈값이 아닌가?
-		if (!StringUtils.hasText(request.getNewDocumentTitle())) {
+		if (!StringUtils.hasText(request.getAfterDocumentTitle())) {
 			throw new BaseException("수정하려는 제목이 비어있습니다.");
 		}
 	}

--- a/src/main/java/goorm/eagle7/stelligence/domain/contribute/ContributeService.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/contribute/ContributeService.java
@@ -50,16 +50,16 @@ public class ContributeService {
 		);
 
 		// 부모 문서 ID가 null 이면 newParentDocument는 null
-		Document newParentDocument = contributeRequest.getNewParentDocumentId() == null ?
-			null : documentContentRepository.findById(contributeRequest.getNewParentDocumentId())
-			.orElseThrow(() -> new BaseException("존재하지 않는 문서의 요청입니다. 부모 문서 ID: " + contributeRequest.getNewParentDocumentId()));
+		Document newParentDocument = contributeRequest.getAfterParentDocumentId() == null ?
+			null : documentContentRepository.findById(contributeRequest.getAfterParentDocumentId())
+			.orElseThrow(() -> new BaseException("존재하지 않는 문서의 요청입니다. 부모 문서 ID: " + contributeRequest.getAfterParentDocumentId()));
 
 		Contribute contribute = Contribute.createContribute(
 			member,
 			document,
 			contributeRequest.getContributeTitle(),
 			contributeRequest.getContributeDescription(),
-			contributeRequest.getNewDocumentTitle(),
+			contributeRequest.getAfterDocumentTitle(),
 			newParentDocument
 		);
 

--- a/src/main/java/goorm/eagle7/stelligence/domain/contribute/ContributeService.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/contribute/ContributeService.java
@@ -49,10 +49,10 @@ public class ContributeService {
 			() -> new BaseException("존재하지 않는 문서의 요청입니다. 문서 ID: " + contributeRequest.getDocumentId())
 		);
 
-		Document newParentDocument = documentContentRepository.findById(contributeRequest.getNewParentDocumentId())
-			.orElseThrow(
-				() -> new BaseException("존재하지 않는 문서의 요청입니다. 부모 문서 ID: " + contributeRequest.getNewParentDocumentId())
-			);
+		// 부모 문서 ID가 null 이면 newParentDocument는 null
+		Document newParentDocument = contributeRequest.getNewParentDocumentId() == null ?
+			null : documentContentRepository.findById(contributeRequest.getNewParentDocumentId())
+			.orElseThrow(() -> new BaseException("존재하지 않는 문서의 요청입니다. 부모 문서 ID: " + contributeRequest.getNewParentDocumentId()));
 
 		Contribute contribute = Contribute.createContribute(
 			member,

--- a/src/main/java/goorm/eagle7/stelligence/domain/contribute/ContributeService.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/contribute/ContributeService.java
@@ -49,8 +49,8 @@ public class ContributeService {
 			() -> new BaseException("존재하지 않는 문서의 요청입니다. 문서 ID: " + contributeRequest.getDocumentId())
 		);
 
-		// 부모 문서 ID가 null 이면 newParentDocument는 null
-		Document newParentDocument = contributeRequest.getAfterParentDocumentId() == null ?
+		// 부모 문서 ID가 null 이면 afterParentDocument는 null
+		Document afterParentDocument = contributeRequest.getAfterParentDocumentId() == null ?
 			null : documentContentRepository.findById(contributeRequest.getAfterParentDocumentId())
 			.orElseThrow(() -> new BaseException("존재하지 않는 문서의 요청입니다. 부모 문서 ID: " + contributeRequest.getAfterParentDocumentId()));
 
@@ -60,7 +60,7 @@ public class ContributeService {
 			contributeRequest.getContributeTitle(),
 			contributeRequest.getContributeDescription(),
 			contributeRequest.getAfterDocumentTitle(),
-			newParentDocument
+			afterParentDocument
 		);
 
 		for (AmendmentRequest request : contributeRequest.getAmendments()) {

--- a/src/main/java/goorm/eagle7/stelligence/domain/contribute/dto/ContributeRequest.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/contribute/dto/ContributeRequest.java
@@ -28,10 +28,10 @@ public class ContributeRequest {
 	private Long documentId;
 
 	@Schema(description = "문서의 변경될 제목", example = "마리모")
-	private String newDocumentTitle;
+	private String afterDocumentTitle;
 
 	@Schema(description = "문서의 변경될 부모 문서 ID", example = "2")
-	private Long newParentDocumentId;
+	private Long afterParentDocumentId;
 
 	@Override
 	public String toString() {
@@ -40,8 +40,8 @@ public class ContributeRequest {
 			+ ", contributeDescription='" + contributeDescription + '\''
 			+ ", amendments=" + amendments
 			+ ", documentId=" + documentId
-			+ ", newDocumentTitle='" + newDocumentTitle + '\''
-			+ ", newParentDocumentId=" + newParentDocumentId
+			+ ", afterDocumentTitle='" + afterDocumentTitle + '\''
+			+ ", afterParentDocumentId=" + afterParentDocumentId
 			+ '}';
 	}
 }

--- a/src/main/java/goorm/eagle7/stelligence/domain/contribute/dto/ContributeResponse.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/contribute/dto/ContributeResponse.java
@@ -16,38 +16,38 @@ public class ContributeResponse {
 	private String contributeTitle;
 	private String contributeDescription;
 	private Long documentId;
-	private String documentTitle;
 	private MemberDetailResponse contributor; //수정 요청한 멤버에 대한 정보
 	private List<AmendmentResponse> amendments;
 
 	// 추가된 필드
-	private String newDocumentTitle;	//변경된 제목
-	private Long existParentDocumentId;	//기존 상위 문서
-	private String existParentDocumentTitle;
-	private Long newParentDocumentId;	//변경된 상위 문서
-	private String newParentDocumentTitle;
+	private String beforeDocumentTitle;	//기존 제목
+	private String afterDocumentTitle;	//변경된 제목
+	private Long beforeParentDocumentId;	//기존 상위 문서
+	private String beforeParentDocumentTitle;
+	private Long afterParentDocumentId;	//변경된 상위 문서
+	private String afterParentDocumentTitle;
 
 	private ContributeResponse(Contribute contribute) {
 		this.contributeId = contribute.getId();
 		this.contributeTitle = contribute.getTitle();
 		this.contributeDescription = contribute.getDescription();
 		this.documentId = contribute.getDocument().getId();
-		this.documentTitle = contribute.getDocument().getTitle();
 		this.contributor = MemberDetailResponse.from(contribute.getMember());
 		this.amendments = contribute.getAmendments().stream()
 			.map(AmendmentResponse::of)
 			.toList();
 
 		// 추가된 생성자
-		this.newDocumentTitle = contribute.getNewDocumentTitle();
-		this.existParentDocumentId = contribute.getDocument().getParentDocument() == null ?
+		this.beforeDocumentTitle = contribute.getBeforeDocumentTitle();
+		this.afterDocumentTitle = contribute.getAfterDocumentTitle();
+		this.beforeParentDocumentId = contribute.getDocument().getParentDocument() == null ?
 			null : contribute.getDocument().getParentDocument().getId();
-		this.existParentDocumentTitle = contribute.getDocument().getParentDocument() == null ?
+		this.beforeParentDocumentTitle = contribute.getDocument().getParentDocument() == null ?
 			null : contribute.getDocument().getParentDocument().getTitle();
-		this.newParentDocumentId = contribute.getNewParentDocument() == null ?
-			null : contribute.getNewParentDocument().getId();
-		this.newParentDocumentTitle = contribute.getNewParentDocument() == null ?
-			null : contribute.getNewParentDocument().getTitle();
+		this.afterParentDocumentId = contribute.getAfterParentDocument() == null ?
+			null : contribute.getAfterParentDocument().getId();
+		this.afterParentDocumentTitle = contribute.getAfterParentDocument() == null ?
+			null : contribute.getAfterParentDocument().getTitle();
 
 	}
 

--- a/src/main/java/goorm/eagle7/stelligence/domain/contribute/dto/ContributeResponse.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/contribute/dto/ContributeResponse.java
@@ -20,6 +20,13 @@ public class ContributeResponse {
 	private MemberDetailResponse contributor; //수정 요청한 멤버에 대한 정보
 	private List<AmendmentResponse> amendments;
 
+	// 추가된 필드
+	private String newDocumentTitle;	//변경된 제목
+	private Long existParentDocumentId;	//기존 상위 문서
+	private String existPatentDocumentTitle;
+	private Long newParentDocumentId;	//변경된 상위 문서
+	private String newPatentDocumentTitle;
+
 	private ContributeResponse(Contribute contribute) {
 		this.contributeId = contribute.getId();
 		this.contributeTitle = contribute.getTitle();
@@ -30,6 +37,18 @@ public class ContributeResponse {
 		this.amendments = contribute.getAmendments().stream()
 			.map(AmendmentResponse::of)
 			.toList();
+
+		// 추가된 생성자
+		this.newDocumentTitle = contribute.getNewDocumentTitle();
+		this.existParentDocumentId = contribute.getDocument().getParentDocument() == null ?
+			null : contribute.getDocument().getParentDocument().getId();
+		this.existPatentDocumentTitle = contribute.getDocument().getParentDocument() == null ?
+			null : contribute.getDocument().getParentDocument().getTitle();
+		this.newParentDocumentId = contribute.getNewParentDocument() == null ?
+			null : contribute.getNewParentDocument().getId();
+		this.newPatentDocumentTitle = contribute.getNewParentDocument() == null ?
+			null : contribute.getNewParentDocument().getTitle();
+
 	}
 
 	public static ContributeResponse of(Contribute contribute) {

--- a/src/main/java/goorm/eagle7/stelligence/domain/contribute/dto/ContributeResponse.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/contribute/dto/ContributeResponse.java
@@ -23,9 +23,9 @@ public class ContributeResponse {
 	// 추가된 필드
 	private String newDocumentTitle;	//변경된 제목
 	private Long existParentDocumentId;	//기존 상위 문서
-	private String existPatentDocumentTitle;
+	private String existParentDocumentTitle;
 	private Long newParentDocumentId;	//변경된 상위 문서
-	private String newPatentDocumentTitle;
+	private String newParentDocumentTitle;
 
 	private ContributeResponse(Contribute contribute) {
 		this.contributeId = contribute.getId();
@@ -42,11 +42,11 @@ public class ContributeResponse {
 		this.newDocumentTitle = contribute.getNewDocumentTitle();
 		this.existParentDocumentId = contribute.getDocument().getParentDocument() == null ?
 			null : contribute.getDocument().getParentDocument().getId();
-		this.existPatentDocumentTitle = contribute.getDocument().getParentDocument() == null ?
+		this.existParentDocumentTitle = contribute.getDocument().getParentDocument() == null ?
 			null : contribute.getDocument().getParentDocument().getTitle();
 		this.newParentDocumentId = contribute.getNewParentDocument() == null ?
 			null : contribute.getNewParentDocument().getId();
-		this.newPatentDocumentTitle = contribute.getNewParentDocument() == null ?
+		this.newParentDocumentTitle = contribute.getNewParentDocument() == null ?
 			null : contribute.getNewParentDocument().getTitle();
 
 	}

--- a/src/main/java/goorm/eagle7/stelligence/domain/contribute/dto/ContributeResponse.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/contribute/dto/ContributeResponse.java
@@ -40,10 +40,10 @@ public class ContributeResponse {
 		// 추가된 생성자
 		this.beforeDocumentTitle = contribute.getBeforeDocumentTitle();
 		this.afterDocumentTitle = contribute.getAfterDocumentTitle();
-		this.beforeParentDocumentId = contribute.getDocument().getParentDocument() == null ?
-			null : contribute.getDocument().getParentDocument().getId();
-		this.beforeParentDocumentTitle = contribute.getDocument().getParentDocument() == null ?
-			null : contribute.getDocument().getParentDocument().getTitle();
+		this.beforeParentDocumentId = contribute.getBeforeParentDocument() == null ?
+			null : contribute.getBeforeParentDocument().getId();
+		this.beforeParentDocumentTitle = contribute.getBeforeParentDocument() == null ?
+			null : contribute.getBeforeParentDocument().getTitle();
 		this.afterParentDocumentId = contribute.getAfterParentDocument() == null ?
 			null : contribute.getAfterParentDocument().getId();
 		this.afterParentDocumentTitle = contribute.getAfterParentDocument() == null ?

--- a/src/main/java/goorm/eagle7/stelligence/domain/contribute/model/Contribute.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/contribute/model/Contribute.java
@@ -69,10 +69,17 @@ public class Contribute extends BaseTimeEntity {
 	private String afterDocumentTitle;
 
 	/**
+	 * 기존 부모 문서입니다.
+	 */
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "before_parent_document_id")
+	private Document beforeParentDocument;
+
+	/**
 	 * 변경될 부모 문서입니다.
 	 */
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "new_parent_document_id")
+	@JoinColumn(name = "after_parent_document_id")
 	private Document afterParentDocument;
 
 	private Contribute(ContributeStatus status, Member member, Document document,
@@ -84,6 +91,7 @@ public class Contribute extends BaseTimeEntity {
 		this.description = description;
 		this.beforeDocumentTitle = document.getTitle();
 		this.afterDocumentTitle = afterDocumentTitle;
+		this.beforeParentDocument = document.getParentDocument();
 		this.afterParentDocument = afterParentDocument;
 	}
 

--- a/src/main/java/goorm/eagle7/stelligence/domain/contribute/model/Contribute.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/contribute/model/Contribute.java
@@ -60,26 +60,31 @@ public class Contribute extends BaseTimeEntity {
 	private String description;
 
 	/**
+	 * 기존 문서 제목입니다.
+	 */
+	private String beforeDocumentTitle;
+	/**
 	 * 변경될 제목입니다.
 	 */
-	private String newDocumentTitle;
+	private String afterDocumentTitle;
 
 	/**
 	 * 변경될 부모 문서입니다.
 	 */
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "new_parent_document_id")
-	private Document newParentDocument;
+	private Document afterParentDocument;
 
 	private Contribute(ContributeStatus status, Member member, Document document,
-		String title, String description, String newDocumentTitle, Document newParentDocument) {
+		String title, String description, String afterDocumentTitle, Document afterParentDocument) {
 		this.status = status;
 		this.member = member;
 		this.document = document;
 		this.title = title;
 		this.description = description;
-		this.newDocumentTitle = newDocumentTitle;
-		this.newParentDocument = newParentDocument;
+		this.beforeDocumentTitle = document.getTitle();
+		this.afterDocumentTitle = afterDocumentTitle;
+		this.afterParentDocument = afterParentDocument;
 	}
 
 	//===생성===//

--- a/src/main/java/goorm/eagle7/stelligence/domain/contribute/scheduler/MergeHandler.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/contribute/scheduler/MergeHandler.java
@@ -1,6 +1,7 @@
 package goorm.eagle7.stelligence.domain.contribute.scheduler;
 
 import java.util.Comparator;
+import java.util.Objects;
 
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
@@ -84,8 +85,13 @@ public class MergeHandler implements ContributeSchedulingActionHandler {
 			documentService.changeDocumentTitle(document.getId(), contribute.getNewDocumentTitle());
 		}
 
-		//Document의 부모 문서를 변경합니다.
-		documentService.changeParentDocument(document.getId(), contribute.getNewParentDocument().getId());
+		// Document의 부모 문서를 변경합니다.
+		// 두 경우 모두 null일 수 있는 가능성을 고려합니다.
+		Long existParentDocumentId = document.getParentDocument() == null ? null : document.getParentDocument().getId();
+		Long newParentDocumentId = contribute.getNewParentDocument() == null ? null : contribute.getNewParentDocument().getId();
+		if (!Objects.equals(existParentDocumentId, newParentDocumentId)) {
+			documentService.changeParentDocument(document.getId(), newParentDocumentId);
+		}
 
 		//문서의 현재 revision을 증가시킵니다.
 		document.incrementCurrentRevision();

--- a/src/main/java/goorm/eagle7/stelligence/domain/contribute/scheduler/MergeHandler.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/contribute/scheduler/MergeHandler.java
@@ -81,14 +81,14 @@ public class MergeHandler implements ContributeSchedulingActionHandler {
 			);
 
 		//Document의 제목을 변경합니다.
-		if (!contribute.getNewDocumentTitle().equals(document.getTitle())) {
-			documentService.changeDocumentTitle(document.getId(), contribute.getNewDocumentTitle());
+		if (!contribute.getAfterDocumentTitle().equals(document.getTitle())) {
+			documentService.changeDocumentTitle(document.getId(), contribute.getAfterDocumentTitle());
 		}
 
 		// Document의 부모 문서를 변경합니다.
 		// 두 경우 모두 null일 수 있는 가능성을 고려합니다.
 		Long existParentDocumentId = document.getParentDocument() == null ? null : document.getParentDocument().getId();
-		Long newParentDocumentId = contribute.getNewParentDocument() == null ? null : contribute.getNewParentDocument().getId();
+		Long newParentDocumentId = contribute.getAfterParentDocument() == null ? null : contribute.getAfterParentDocument().getId();
 		if (!Objects.equals(existParentDocumentId, newParentDocumentId)) {
 			documentService.changeParentDocument(document.getId(), newParentDocumentId);
 		}

--- a/src/main/java/goorm/eagle7/stelligence/domain/contribute/scheduler/MergeHandler.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/contribute/scheduler/MergeHandler.java
@@ -81,16 +81,17 @@ public class MergeHandler implements ContributeSchedulingActionHandler {
 			);
 
 		//Document의 제목을 변경합니다.
-		if (!contribute.getAfterDocumentTitle().equals(document.getTitle())) {
+		if (!contribute.getAfterDocumentTitle().equals(contribute.getBeforeDocumentTitle())) {
 			documentService.changeDocumentTitle(document.getId(), contribute.getAfterDocumentTitle());
 		}
 
 		// Document의 부모 문서를 변경합니다.
 		// 두 경우 모두 null일 수 있는 가능성을 고려합니다.
-		Long existParentDocumentId = document.getParentDocument() == null ? null : document.getParentDocument().getId();
-		Long newParentDocumentId = contribute.getAfterParentDocument() == null ? null : contribute.getAfterParentDocument().getId();
-		if (!Objects.equals(existParentDocumentId, newParentDocumentId)) {
-			documentService.changeParentDocument(document.getId(), newParentDocumentId);
+		// 부모 문서가 동일한 경우에는 업데이트하지 않습니다.
+		Long beforeParentDocumentId = contribute.getBeforeParentDocument() == null ? null : contribute.getBeforeParentDocument().getId();
+		Long afterParentDocumentId = contribute.getAfterParentDocument() == null ? null : contribute.getAfterParentDocument().getId();
+		if (!Objects.equals(beforeParentDocumentId, afterParentDocumentId)) {
+			documentService.changeParentDocument(document.getId(), afterParentDocumentId);
 		}
 
 		//문서의 현재 revision을 증가시킵니다.

--- a/src/main/java/goorm/eagle7/stelligence/domain/document/DocumentService.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/document/DocumentService.java
@@ -140,6 +140,7 @@ public class DocumentService {
 	 */
 	@Transactional
 	public void changeParentDocument(Long documentId, Long newParentDocumentId) {
+		documentContentService.updateParentDocument(documentId, newParentDocumentId);
 		documentGraphService.updateDocumentLink(documentId, newParentDocumentId);
 	}
 }

--- a/src/main/java/goorm/eagle7/stelligence/domain/document/DocumentService.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/document/DocumentService.java
@@ -50,7 +50,7 @@ public class DocumentService {
 
 		//DocumentContent 저장
 		Document createdDocument = documentContentService.createDocument(documentCreateRequest.getTitle(),
-			documentCreateRequest.getContent(), author);
+			documentCreateRequest.getContent(), documentCreateRequest.getParentDocumentId(), author);
 
 		//DocumentLink 저장 - 지정한 부모 문서가 있다면 링크 연결
 		if (documentCreateRequest.getParentDocumentId() == null) {

--- a/src/main/java/goorm/eagle7/stelligence/domain/document/DocumentService.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/document/DocumentService.java
@@ -130,7 +130,7 @@ public class DocumentService {
 		documentContentService.changeTitle(documentId, newTitle);
 
 		//DocumentNode의 제목도 변경합니다.
-		//documentGraphService.changeDocumentTitle(documentId, newTitle);
+		documentGraphService.changeTitle(documentId, newTitle);
 	}
 
 	/**

--- a/src/main/java/goorm/eagle7/stelligence/domain/document/content/DocumentContentService.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/document/content/DocumentContentService.java
@@ -48,13 +48,18 @@ public class DocumentContentService {
 	 * 외부에서 호출시 DocumentGraph와 Content 간 일관성이 깨지는 문제가 발생될 수 있습니다.
 	 * @param title 문서의 제목
 	 * @param rawContent 사용자가 작성한 글 내용
+	 * @param parentDocumentId 부모 문서의 ID : 루트 문서를 생성하는 경우 null
 	 */
 	@Transactional
-	public Document createDocument(String title, String rawContent, Member author) {
+	public Document createDocument(String title, String rawContent, Long parentDocumentId, Member author) {
 		log.trace("DocumentService.createDocument called");
 
+		//부모 문서가 존재하는지 확인합니다.
+		Document parentDocument = parentDocumentId == null ? null : documentRepository.findById(parentDocumentId)
+			.orElseThrow(() -> new BaseException("부모 문서가 존재하지 않습니다. 문서 ID : " + parentDocumentId));
+
 		//document 생성
-		Document document = Document.createDocument(title, author);
+		Document document = Document.createDocument(title, author, parentDocument);
 		documentRepository.save(document);
 
 		List<SectionRequest> sectionRequests = documentParser.parse(rawContent);

--- a/src/main/java/goorm/eagle7/stelligence/domain/document/content/DocumentContentService.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/document/content/DocumentContentService.java
@@ -154,7 +154,7 @@ public class DocumentContentService {
 
 	/**
 	 * 상위 문서를 변경합니다.
-	 * newParentDocumentId가 null인 경우 상위 문서를 삭제합니다.
+	 * newParentDocumentId가 null인 경우 상위 문서 참조를 삭제합니다.
 	 * @param documentId 상위 문서를 변경하려는 문서 ID
 	 * @param newParentDocumentId 상위 문서 ID
 	 */

--- a/src/main/java/goorm/eagle7/stelligence/domain/document/content/DocumentContentService.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/document/content/DocumentContentService.java
@@ -150,4 +150,16 @@ public class DocumentContentService {
 		document.changeTitle(newTitle);
 	}
 
+	// TODO 테스트
+	@Transactional
+	public void updateParentDocument(Long documentId, Long newParentDocumentId) {
+
+		Document document = documentRepository.findById(documentId)
+			.orElseThrow(() -> new BaseException("문서가 존재하지 않습니다. 문서 ID : " + documentId));
+
+		Document parentDocument = newParentDocumentId == null ? null : documentRepository.findById(newParentDocumentId)
+			.orElseThrow(() -> new BaseException("상위 문서가 존재하지 않습니다. 문서 ID : " + newParentDocumentId));
+
+		document.updateParentDocument(parentDocument);
+	}
 }

--- a/src/main/java/goorm/eagle7/stelligence/domain/document/content/DocumentContentService.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/document/content/DocumentContentService.java
@@ -150,7 +150,12 @@ public class DocumentContentService {
 		document.changeTitle(newTitle);
 	}
 
-	// TODO 테스트
+	/**
+	 * 상위 문서를 변경합니다.
+	 * newParentDocumentId가 null인 경우 상위 문서를 삭제합니다.
+	 * @param documentId 상위 문서를 변경하려는 문서 ID
+	 * @param newParentDocumentId 상위 문서 ID
+	 */
 	@Transactional
 	public void updateParentDocument(Long documentId, Long newParentDocumentId) {
 

--- a/src/main/java/goorm/eagle7/stelligence/domain/document/content/DocumentContentService.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/document/content/DocumentContentService.java
@@ -140,7 +140,9 @@ public class DocumentContentService {
 	}
 
 	/**
-	 * 제목을 변경합니다.
+	 * 문서의 제목을 변경합니다.
+	 * @param documentId 제목을 변경할 문서 ID
+	 * @param newTitle 변경할 문서 제목
 	 */
 	@Transactional
 	public void changeTitle(Long documentId, String newTitle) {

--- a/src/main/java/goorm/eagle7/stelligence/domain/document/content/model/Document.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/document/content/model/Document.java
@@ -70,12 +70,20 @@ public class Document extends BaseTimeEntity {
 	@OneToMany(mappedBy = "document")
 	private List<Section> sections = new ArrayList<>();
 
+	/**
+	 * Document와 연결되어있는 상위 Document입니다.
+	 */
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "parent_document_id")
+	private Document parentDocument;
+
 	//===생성===//
-	public static Document createDocument(String title, Member author) {
+	public static Document createDocument(String title, Member author, Document parentDocument) {
 		Document document = new Document();
 		document.title = title;
 		document.author = author;
 		document.currentRevision = 1L; //최초 생성 시 버전은 1입니다.
+		document.parentDocument = parentDocument;
 		return document;
 	}
 

--- a/src/main/java/goorm/eagle7/stelligence/domain/document/content/model/Document.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/document/content/model/Document.java
@@ -105,4 +105,11 @@ public class Document extends BaseTimeEntity {
 		this.title = newTitle;
 	}
 
+	/**
+	 * parentDocument를 변경합니다.
+	 * @param parentDocument 변경될 상위 문서
+	 */
+	public void updateParentDocument(Document parentDocument) {
+		this.parentDocument = parentDocument;
+	}
 }

--- a/src/main/java/goorm/eagle7/stelligence/domain/document/graph/DocumentGraphService.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/document/graph/DocumentGraphService.java
@@ -162,7 +162,7 @@ public class DocumentGraphService {
 
 	@Transactional
 	@CacheEvict(value="RootGraph", allEntries = true, cacheManager = "cacheManager")
-	public void updateDocumentTitle(Long documentId, String updateTitle) {
+	public void changeTitle(Long documentId, String updateTitle) {
 
 		DocumentNode documentNode = documentNodeRepository.findById(documentId)
 			.orElseThrow(() -> new BaseException("존재하지 않는 노드에 대한 제목 수정 요청입니다. 문서 ID: " + documentId));

--- a/src/test/java/goorm/eagle7/stelligence/config/mockdata/TestFixtureGenerator.java
+++ b/src/test/java/goorm/eagle7/stelligence/config/mockdata/TestFixtureGenerator.java
@@ -228,7 +228,7 @@ public class TestFixtureGenerator {
 	}
 
 	public static Contribute contribute(Long id, Member contributor, ContributeStatus status, Document document,
-		String newDocumentTitle, Document newParentDocument) {
+		String afterDocumentTitle, Document afterParentDocument) {
 		try {
 			Class<?> contributeClazz = Class.forName("goorm.eagle7.stelligence.domain.contribute.model.Contribute");
 
@@ -242,15 +242,17 @@ public class TestFixtureGenerator {
 			Field statusField = contributeClazz.getDeclaredField("status");
 			Field documentField = contributeClazz.getDeclaredField("document");
 			Field amendmentsField = contributeClazz.getDeclaredField("amendments");
-			Field newDocumentTitleField = contributeClazz.getDeclaredField("newDocumentTitle");
-			Field newParentDocumentField = contributeClazz.getDeclaredField("newParentDocument");
+			Field beforeDocumentTitleField = contributeClazz.getDeclaredField("beforeDocumentTitle");
+			Field afterDocumentTitleField = contributeClazz.getDeclaredField("afterDocumentTitle");
+			Field newParentDocumentField = contributeClazz.getDeclaredField("afterParentDocument");
 
 			idField.setAccessible(true);
 			contributorField.setAccessible(true);
 			statusField.setAccessible(true);
 			documentField.setAccessible(true);
 			amendmentsField.setAccessible(true);
-			newDocumentTitleField.setAccessible(true);
+			beforeDocumentTitleField.setAccessible(true);
+			afterDocumentTitleField.setAccessible(true);
 			newParentDocumentField.setAccessible(true);
 
 			idField.set(contribute, id);
@@ -258,8 +260,9 @@ public class TestFixtureGenerator {
 			statusField.set(contribute, status);
 			documentField.set(contribute, document);
 			amendmentsField.set(contribute, new ArrayList<>());
-			newDocumentTitleField.set(contribute, newDocumentTitle);
-			newParentDocumentField.set(contribute, newParentDocument);
+			beforeDocumentTitleField.set(contribute, document.getTitle());
+			afterDocumentTitleField.set(contribute, afterDocumentTitle);
+			newParentDocumentField.set(contribute, afterParentDocument);
 
 			return (Contribute)contribute;
 

--- a/src/test/java/goorm/eagle7/stelligence/config/mockdata/TestFixtureGenerator.java
+++ b/src/test/java/goorm/eagle7/stelligence/config/mockdata/TestFixtureGenerator.java
@@ -31,7 +31,8 @@ public class TestFixtureGenerator {
 	private TestFixtureGenerator() {
 	}
 
-	public static Document document(Long id, Member author, String title, Long currentRevision) {
+	public static Document document(Long id, Member author, String title, Long currentRevision,
+		Document parentDocument) {
 		try {
 			Class<?> documentClass = Class.forName("goorm.eagle7.stelligence.domain.document.content.model.Document");
 
@@ -47,22 +48,29 @@ public class TestFixtureGenerator {
 			Field authorField = documentClass.getDeclaredField("author");
 			Field currentRevisionField = documentClass.getDeclaredField("currentRevision");
 			Field sectionsField = documentClass.getDeclaredField("sections");
+			Field parentDocumentField = documentClass.getDeclaredField("parentDocument");
 
 			idField.setAccessible(true);
 			titleField.setAccessible(true);
 			authorField.setAccessible(true);
 			currentRevisionField.setAccessible(true);
 			sectionsField.setAccessible(true);
+			parentDocumentField.setAccessible(true);
 
 			idField.set(document, id);
 			titleField.set(document, title);
 			authorField.set(document, author); // Member 객체 필요
 			currentRevisionField.set(document, currentRevision);
+			parentDocumentField.set(document, parentDocument);
 
 			return (Document)document;
 		} catch (Exception e) {
 			throw new RuntimeException(e);
 		}
+	}
+
+	public static Document document(Long id, Member author, String title, Long currentRevision) {
+		return document(id, author, title, currentRevision, null);
 	}
 
 	public static Member member(Long id, Role role, long contributes, String name, String nickname, String email,

--- a/src/test/java/goorm/eagle7/stelligence/domain/contribute/ContributeRequestValidatorTest.java
+++ b/src/test/java/goorm/eagle7/stelligence/domain/contribute/ContributeRequestValidatorTest.java
@@ -66,6 +66,21 @@ class ContributeRequestValidatorTest {
 	}
 
 	@Test
+	@DisplayName("변경요청된 제목이 비어있는 경우")
+	void emptyTitle() {
+		//given
+		ContributeRequest contributeRequest = new ContributeRequest("title", "description",
+			null, 1L, " ", 2L);
+
+		//when
+
+		//then
+		assertThatThrownBy(
+			() -> contributeRequestValidator.validate(contributeRequest)
+		).isInstanceOf(BaseException.class).hasMessage("수정하려는 제목이 비어있습니다.");
+	}
+
+	@Test
 	@DisplayName("documentId에 해당하는 문서가 존재하지 않는 경우")
 	void noDocument() {
 		//given
@@ -157,27 +172,5 @@ class ContributeRequestValidatorTest {
 		assertThatThrownBy(
 			() -> contributeRequestValidator.validate(contributeRequest)
 		).isInstanceOf(BaseException.class).hasMessage("생성 순서가 순차적이지 않습니다.");
-	}
-
-	@Test
-	@DisplayName("변경요청된 제목이 비어있는 경우")
-	void emptyTitle() {
-		//given
-		AmendmentRequest a1 = new AmendmentRequest(1L, AmendmentType.CREATE, Heading.H2, "title",
-			"content", 1);
-		AmendmentRequest a2 = new AmendmentRequest(1L, AmendmentType.CREATE, Heading.H2, "title",
-			"content", 2);
-		ContributeRequest contributeRequest = new ContributeRequest("title", "description",
-			List.of(a1, a2), 1L, " ", 2L);
-
-		//when
-		when(documentContentRepository.findById(1L)).thenReturn(Optional.of(mock(Document.class)));
-		when(contributeRepository.existsByDocumentAndStatus(any(), any())).thenReturn(false);
-		when(sectionRepository.findSectionIdByVersion(any(), any())).thenReturn(List.of(1L, 2L));
-
-
-		assertThatThrownBy(
-			() -> contributeRequestValidator.validate(contributeRequest)
-		).isInstanceOf(BaseException.class).hasMessage("수정하려는 제목이 비어있습니다.");
 	}
 }

--- a/src/test/java/goorm/eagle7/stelligence/domain/contribute/ContributeRequestValidatorTest.java
+++ b/src/test/java/goorm/eagle7/stelligence/domain/contribute/ContributeRequestValidatorTest.java
@@ -158,4 +158,26 @@ class ContributeRequestValidatorTest {
 			() -> contributeRequestValidator.validate(contributeRequest)
 		).isInstanceOf(BaseException.class).hasMessage("생성 순서가 순차적이지 않습니다.");
 	}
+
+	@Test
+	@DisplayName("변경요청된 제목이 비어있는 경우")
+	void emptyTitle() {
+		//given
+		AmendmentRequest a1 = new AmendmentRequest(1L, AmendmentType.CREATE, Heading.H2, "title",
+			"content", 1);
+		AmendmentRequest a2 = new AmendmentRequest(1L, AmendmentType.CREATE, Heading.H2, "title",
+			"content", 2);
+		ContributeRequest contributeRequest = new ContributeRequest("title", "description",
+			List.of(a1, a2), 1L, " ", 2L);
+
+		//when
+		when(documentContentRepository.findById(1L)).thenReturn(Optional.of(mock(Document.class)));
+		when(contributeRepository.existsByDocumentAndStatus(any(), any())).thenReturn(false);
+		when(sectionRepository.findSectionIdByVersion(any(), any())).thenReturn(List.of(1L, 2L));
+
+
+		assertThatThrownBy(
+			() -> contributeRequestValidator.validate(contributeRequest)
+		).isInstanceOf(BaseException.class).hasMessage("수정하려는 제목이 비어있습니다.");
+	}
 }

--- a/src/test/java/goorm/eagle7/stelligence/domain/contribute/scheduler/ContributeSchedulingActionDeterminerTest.java
+++ b/src/test/java/goorm/eagle7/stelligence/domain/contribute/scheduler/ContributeSchedulingActionDeterminerTest.java
@@ -13,6 +13,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import goorm.eagle7.stelligence.domain.contribute.model.Contribute;
 import goorm.eagle7.stelligence.domain.contribute.model.ContributeStatus;
+import goorm.eagle7.stelligence.domain.document.content.model.Document;
 import goorm.eagle7.stelligence.domain.vote.custom.CustomVoteRepository;
 import goorm.eagle7.stelligence.domain.vote.model.VoteSummary;
 
@@ -28,7 +29,8 @@ class ContributeSchedulingActionDeterminerTest {
 	@Test
 	void merge() {
 		//given
-		Contribute contribute = contribute(1L, null, ContributeStatus.VOTING, null);
+		Document document = document(1L, null, "title", null);
+		Contribute contribute = contribute(1L, null, ContributeStatus.VOTING, document);
 
 		//when
 		when(voteCustomRepository.getVoteSummary(contribute.getId())).thenReturn(
@@ -42,7 +44,8 @@ class ContributeSchedulingActionDeterminerTest {
 	@Test
 	void debate() {
 		//given
-		Contribute contribute = contribute(1L, null, ContributeStatus.VOTING, null);
+		Document document = document(1L, null, "title", null);
+		Contribute contribute = contribute(1L, null, ContributeStatus.VOTING, document);
 
 		//when
 		when(voteCustomRepository.getVoteSummary(contribute.getId())).thenReturn(
@@ -56,7 +59,8 @@ class ContributeSchedulingActionDeterminerTest {
 	@Test
 	void reject() {
 		//given
-		Contribute contribute = contribute(1L, null, ContributeStatus.VOTING, null);
+		Document document = document(1L, null, "title", null);
+		Contribute contribute = contribute(1L, null, ContributeStatus.VOTING, document);
 
 		//when
 		when(voteCustomRepository.getVoteSummary(contribute.getId())).thenReturn(
@@ -71,7 +75,8 @@ class ContributeSchedulingActionDeterminerTest {
 	@DisplayName("투표가 없으면 반려")
 	void rejectWhenNoVote() {
 		//given
-		Contribute contribute = contribute(1L, null, ContributeStatus.VOTING, null);
+		Document document = document(1L, null, "title", null);
+		Contribute contribute = contribute(1L, null, ContributeStatus.VOTING, document);
 
 		//when
 		when(voteCustomRepository.getVoteSummary(contribute.getId())).thenReturn(

--- a/src/test/java/goorm/eagle7/stelligence/domain/contribute/scheduler/DebateHandlerTest.java
+++ b/src/test/java/goorm/eagle7/stelligence/domain/contribute/scheduler/DebateHandlerTest.java
@@ -18,6 +18,7 @@ import goorm.eagle7.stelligence.domain.contribute.model.Contribute;
 import goorm.eagle7.stelligence.domain.contribute.model.ContributeStatus;
 import goorm.eagle7.stelligence.domain.debate.repository.DebateRepository;
 import goorm.eagle7.stelligence.domain.debate.model.Debate;
+import goorm.eagle7.stelligence.domain.document.content.model.Document;
 
 @ExtendWith(MockitoExtension.class)
 class DebateHandlerTest {
@@ -36,7 +37,8 @@ class DebateHandlerTest {
 	void debateHandling() {
 		//given
 		Long contributeId = 1L;
-		Contribute contribute = contribute(contributeId, null, ContributeStatus.VOTING, null);
+		Document document = document(1L, null, "title", null);
+		Contribute contribute = contribute(contributeId, null, ContributeStatus.VOTING, document);
 
 		when(contributeRepository.findById(contributeId)).thenReturn(Optional.of(contribute));
 
@@ -57,9 +59,10 @@ class DebateHandlerTest {
 		Long mergedContributeId = 2L;
 		Long rejectedContributeId = 3L;
 
-		Contribute debatingContribute = contribute(debatingContributeId, null, ContributeStatus.DEBATING, null);
-		Contribute mergedContribute = contribute(mergedContributeId, null, ContributeStatus.MERGED, null);
-		Contribute rejectedContribute = contribute(rejectedContributeId, null, ContributeStatus.REJECTED, null);
+		Document document = document(1L, null, "title", null);
+		Contribute debatingContribute = contribute(debatingContributeId, null, ContributeStatus.DEBATING, document);
+		Contribute mergedContribute = contribute(mergedContributeId, null, ContributeStatus.MERGED, document);
+		Contribute rejectedContribute = contribute(rejectedContributeId, null, ContributeStatus.REJECTED, document);
 
 		when(contributeRepository.findById(debatingContributeId)).thenReturn(Optional.of(debatingContribute));
 		when(contributeRepository.findById(mergedContributeId)).thenReturn(Optional.of(mergedContribute));

--- a/src/test/java/goorm/eagle7/stelligence/domain/contribute/scheduler/MergeHandlerTest.java
+++ b/src/test/java/goorm/eagle7/stelligence/domain/contribute/scheduler/MergeHandlerTest.java
@@ -4,6 +4,8 @@ import static goorm.eagle7.stelligence.config.mockdata.TestFixtureGenerator.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import java.util.Optional;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -11,6 +13,7 @@ import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.stubbing.Answer;
 import org.springframework.cache.CacheManager;
 
 import goorm.eagle7.stelligence.domain.amendment.model.Amendment;
@@ -203,5 +206,52 @@ class MergeHandlerTest {
 		inOrder.verify(updateAmendmentMergeTemplate).handle(document, a1);
 		inOrder.verify(deleteAmendmentMergeTemplate).handle(document, a2);
 		inOrder.verify(updateAmendmentMergeTemplate).handle(document, a3);
+	}
+
+	@Test
+	@DisplayName("제목 변경 테스트")
+	void changeTitle() {
+		//given
+		Member member = member(1L, "pete");
+		Document document = document(1L, member, "title", 1L);
+		Contribute contribute = contribute(1L, member, ContributeStatus.VOTING, document, "changedTitle", null);
+
+		//when
+		when(contributeRepository.findByIdWithAmendmentsAndMember(1L)).thenReturn(Optional.of(contribute));
+		doAnswer((Answer<Void>)invocation -> {
+			document.changeTitle("changedTitle");
+			return null;
+		}).when(documentService).changeDocumentTitle(1L, "changedTitle");
+
+		mergeHandler.handle(contribute.getId());
+
+		//then
+		assertThat(contribute.getBeforeDocumentTitle()).isEqualTo("title");
+		assertThat(contribute.getAfterDocumentTitle()).isEqualTo("changedTitle");
+		assertThat(document.getTitle()).isEqualTo("changedTitle");
+	}
+
+	@Test
+	@DisplayName("부모 문서 변경 테스트")
+	void changeParentDocument() {
+		//given
+		Member member = member(1L, "pete");
+		Document document = document(1L, member, "title", 1L);
+		Document afterParentDocument = document(2L, member, "parent", 1L);
+		Contribute contribute = contribute(1L, member, ContributeStatus.VOTING, document, "changedTitle", afterParentDocument);
+
+		//when
+		when(contributeRepository.findByIdWithAmendmentsAndMember(1L)).thenReturn(Optional.of(contribute));
+		doAnswer((Answer<Void>)invocation -> {
+			document.updateParentDocument(afterParentDocument);
+			return null;
+		}).when(documentService).changeParentDocument(1L, 2L);
+
+		mergeHandler.handle(contribute.getId());
+
+		//then
+		assertThat(contribute.getBeforeParentDocument()).isNull();
+		assertThat(contribute.getAfterParentDocument()).isEqualTo(afterParentDocument);
+		assertThat(document.getParentDocument()).isEqualTo(afterParentDocument);
 	}
 }

--- a/src/test/java/goorm/eagle7/stelligence/domain/contribute/scheduler/MergeHandlerTest.java
+++ b/src/test/java/goorm/eagle7/stelligence/domain/contribute/scheduler/MergeHandlerTest.java
@@ -97,9 +97,9 @@ class MergeHandlerTest {
 		verify(deleteAmendmentMergeTemplate, times(1)).handle(document, a2);
 
 		//제목변경과 부모 문서 변경 메서드가 각각 1번씩 호출되었는지 확인
-		verify(documentService, times(1)).changeDocumentTitle(document.getId(), contribute.getNewDocumentTitle());
+		verify(documentService, times(1)).changeDocumentTitle(document.getId(), contribute.getAfterDocumentTitle());
 		verify(documentService, times(1)).changeParentDocument(document.getId(),
-			contribute.getNewParentDocument().getId());
+			contribute.getAfterParentDocument().getId());
 
 	}
 

--- a/src/test/java/goorm/eagle7/stelligence/domain/contribute/scheduler/RejectHandlerTest.java
+++ b/src/test/java/goorm/eagle7/stelligence/domain/contribute/scheduler/RejectHandlerTest.java
@@ -13,6 +13,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import goorm.eagle7.stelligence.domain.contribute.ContributeRepository;
 import goorm.eagle7.stelligence.domain.contribute.model.Contribute;
 import goorm.eagle7.stelligence.domain.contribute.model.ContributeStatus;
+import goorm.eagle7.stelligence.domain.document.content.model.Document;
 
 @ExtendWith(MockitoExtension.class)
 class RejectHandlerTest {
@@ -26,7 +27,8 @@ class RejectHandlerTest {
 	@Test
 	void handleTest() {
 		//given
-		Contribute contribute = contribute(1L, null, ContributeStatus.VOTING, null);
+		Document document = document(1L, null, "title", null);
+		Contribute contribute = contribute(1L, null, ContributeStatus.VOTING, document);
 
 		//when
 		when(contributeRepository.findById(contribute.getId())).thenReturn(java.util.Optional.of(contribute));

--- a/src/test/java/goorm/eagle7/stelligence/domain/document/DocumentServiceTest.java
+++ b/src/test/java/goorm/eagle7/stelligence/domain/document/DocumentServiceTest.java
@@ -107,4 +107,34 @@ class DocumentServiceTest {
 		//then
 		verify(documentGraphService, times(1)).findGraphWithDepth(1L, 3);
 	}
+
+	@Test
+	@DisplayName("문서 제목 변경")
+	void changeDocumentTitle() {
+		//given
+		Long documentId = 1L;
+		String updateTitle = "updateTitle";
+
+		// when
+		documentService.changeDocumentTitle(documentId, updateTitle);
+
+		//then
+		verify(documentContentService, times(1)).changeTitle(documentId, updateTitle);
+		verify(documentGraphService, times(1)).changeTitle(documentId, updateTitle);
+	}
+
+	@Test
+	@DisplayName("상위 문서 변경")
+	void changeParentDocument() {
+		//given
+		Long documentId = 1L;
+		Long parentDocumentId = 2L;
+
+		// when
+		documentService.changeParentDocument(documentId, parentDocumentId);
+
+		//then
+		verify(documentContentService, times(1)).updateParentDocument(documentId, parentDocumentId);
+		verify(documentGraphService, times(1)).updateDocumentLink(documentId, parentDocumentId);
+	}
 }

--- a/src/test/java/goorm/eagle7/stelligence/domain/document/DocumentServiceTest.java
+++ b/src/test/java/goorm/eagle7/stelligence/domain/document/DocumentServiceTest.java
@@ -49,7 +49,7 @@ class DocumentServiceTest {
 		);
 
 		when(memberRepository.findById(author.getId())).thenReturn(Optional.of(author));
-		when(documentContentService.createDocument("testTitle", "testSectionContent", author))
+		when(documentContentService.createDocument("testTitle", "testSectionContent", null, author))
 			.thenReturn(document);
 
 		//when
@@ -61,7 +61,7 @@ class DocumentServiceTest {
 		//then
 		//memberRepository, documentContentService, documentGraphService가 각각 한 번씩 호출되어야 합니다.
 		verify(memberRepository, times(1)).findById(author.getId());
-		verify(documentContentService, times(1)).createDocument("testTitle", "testSectionContent", author);
+		verify(documentContentService, times(1)).createDocument("testTitle", "testSectionContent", null, author);
 		verify(documentGraphService, times(1)).createDocumentNode(document);
 
 		//기여한 글 개수가 올라야 합니다.

--- a/src/test/java/goorm/eagle7/stelligence/domain/document/content/DocumentContentServiceCreateUnitTest.java
+++ b/src/test/java/goorm/eagle7/stelligence/domain/document/content/DocumentContentServiceCreateUnitTest.java
@@ -63,7 +63,7 @@ class DocumentContentServiceCreateUnitTest {
 		when(documentParser.parse(rawContent)).thenReturn(sectionRequests);
 
 		//when
-		Document document = documentContentService.createDocument(title, rawContent, author);
+		Document document = documentContentService.createDocument(title, rawContent, null, author);
 
 		//then
 

--- a/src/test/java/goorm/eagle7/stelligence/domain/document/content/DocumentContentServiceCreateUnitTest.java
+++ b/src/test/java/goorm/eagle7/stelligence/domain/document/content/DocumentContentServiceCreateUnitTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.*;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -45,8 +46,8 @@ class DocumentContentServiceCreateUnitTest {
 	DocumentContentService documentContentService;
 
 	@Test
-	@DisplayName("문서 생성 - 성공")
-	void createDocumentSuccess() {
+	@DisplayName("문서 생성 - 부모 문서 없는 경우 - 성공")
+	void createDocumentNoParentSuccess() {
 		//given
 		String title = "title";
 		String rawContent = "# title1\ntestRawContent";
@@ -77,12 +78,41 @@ class DocumentContentServiceCreateUnitTest {
 		assertThat(document.getTitle()).isEqualTo(title);
 		assertThat(document.getAuthor().getNickname()).isEqualTo(nickname);
 		assertThat(document.getSections()).hasSize(2);
+		//부모 문서가 없으므로 null
+		assertThat(document.getParentDocument()).isNull();
 
 		//section의 값이 정상적으로 들어갔는지 확인
 		assertThat(document.getSections().get(0).getHeading()).isEqualTo(Heading.H1);
 		assertThat(document.getSections().get(1).getTitle()).isEqualTo("title2");
 		assertThat(document.getSections().get(0).getOrder()).isEqualTo(1);
 		assertThat(document.getSections().get(1).getOrder()).isEqualTo(2);
+	}
+
+	@Test
+	@DisplayName("문서 생성 - 부모 문서 있는 경우 - 성공")
+	void createDocumentWithParentSuccess() {
+		//given
+		String title = "title";
+		String rawContent = "# title1\ntestRawContent";
+		String nickname = "nickname";
+
+		Member author = member(1L, nickname);
+		Document parent = document(2L, author, "title", 1L);
+
+		//문서 파싱 결과
+		List<SectionRequest> sectionRequests = new ArrayList<>();
+		sectionRequests.add(new SectionRequest(Heading.H1, "title1", "testRawContent\n"));
+		sectionRequests.add(new SectionRequest(Heading.H2, "title2", "content2 line 1\ncontent2 line 2\n"));
+
+		//when
+		when(documentParser.parse(rawContent)).thenReturn(sectionRequests);
+		when(documentContentRepository.findById(2L)).thenReturn(
+			Optional.of(parent));
+		Document document = documentContentService.createDocument(title, rawContent, 2L, author);
+
+		//then
+		//부모 문서가 없으므로 null
+		assertThat(document.getParentDocument()).isEqualTo(parent);
 	}
 
 }

--- a/src/test/java/goorm/eagle7/stelligence/domain/document/content/DocumentContentServiceTest.java
+++ b/src/test/java/goorm/eagle7/stelligence/domain/document/content/DocumentContentServiceTest.java
@@ -38,4 +38,60 @@ class DocumentContentServiceTest {
 		assertThat(document.getTitle()).isEqualTo("changedTitle");
 
 	}
+
+	@Test
+	@DisplayName("상위 문서 링크 변경 테스트: 기존 상위 문서 없는 경우")
+	void updateParentDocumentFromNull() {
+		// given
+		Long documentId = 1L;
+		Long parentDocumentId = 2L;
+		Document document = document(documentId, member(1L, "author1"), "title1", 1L, null);
+		Document parentDocument = document(parentDocumentId, member(2L, "author2"), "title2", 1L);
+
+		when(documentContentRepository.findById(documentId)).thenReturn(java.util.Optional.of(document));
+		when(documentContentRepository.findById(parentDocumentId)).thenReturn(java.util.Optional.of(parentDocument));
+
+		// when
+		documentContentService.updateParentDocument(documentId, parentDocumentId);
+
+		//then
+		assertThat(document.getParentDocument()).isEqualTo(parentDocument);
+	}
+
+	@Test
+	@DisplayName("상위 문서 링크 변경 테스트: 기존 상위 문서 있던 경우")
+	void updateParentDocument() {
+		// given
+		Long documentId = 1L;
+		Long parentDocumentId = 2L;
+		Document existParentDocument = document(99L, member(99L, "author99"), "title99", 1L);
+		Document document = document(documentId, member(1L, "author1"), "title1", 1L, existParentDocument);
+		Document parentDocument = document(parentDocumentId, member(2L, "author2"), "title2", 1L);
+
+		when(documentContentRepository.findById(documentId)).thenReturn(java.util.Optional.of(document));
+		when(documentContentRepository.findById(parentDocumentId)).thenReturn(java.util.Optional.of(parentDocument));
+
+		// when
+		documentContentService.updateParentDocument(documentId, parentDocumentId);
+
+		//then
+		assertThat(document.getParentDocument()).isEqualTo(parentDocument);
+	}
+
+	@Test
+	@DisplayName("상위 문서 링크 삭제 테스트: 기존 상위 문서 있던 경우")
+	void updateParentDocumentToNull() {
+		// given
+		Long documentId = 1L;
+		Document existParentDocument = document(99L, member(99L, "author99"), "title99", 1L);
+		Document document = document(documentId, member(1L, "author1"), "title1", 1L, existParentDocument);
+
+		when(documentContentRepository.findById(documentId)).thenReturn(java.util.Optional.of(document));
+
+		// when
+		documentContentService.updateParentDocument(documentId, null);
+
+		//then
+		assertThat(document.getParentDocument()).isNull();
+	}
 }

--- a/src/test/java/goorm/eagle7/stelligence/domain/document/graph/DocumentGraphServiceTest.java
+++ b/src/test/java/goorm/eagle7/stelligence/domain/document/graph/DocumentGraphServiceTest.java
@@ -41,7 +41,7 @@ class DocumentGraphServiceTest {
 	@DisplayName("최상위 문서 노드 생성 서비스 테스트")
 	void createDocumentNode() {
 
-		Document createdDocument = Document.createDocument("제목1", member(null, "Paul"));
+		Document createdDocument = document(null, member(null, "Paul"), "제목1", 1L, null);
 		documentContentRepository.save(createdDocument);
 
 		documentGraphService.createDocumentNode(createdDocument);
@@ -60,12 +60,12 @@ class DocumentGraphServiceTest {
 	void createDocumentNodeWithParent() {
 
 		// 기존에 존재하는 상위 문서
-		Document parentDocument = Document.createDocument("상위 문서 제목", member(null, "Paul"));
+		Document parentDocument = document(null, member(null, "Paul"), "제목1", 1L, null);
 		documentContentRepository.save(parentDocument);
 		documentGraphService.createDocumentNode(parentDocument);
 
 		// 하위 문서 생성
-		Document createdDocument = Document.createDocument("하위 문서 제목", member(null, "Paul"));
+		Document createdDocument = document(null, member(null, "Paul"), "제목2", 1L, parentDocument);
 		documentContentRepository.save(createdDocument);
 		documentGraphService.createDocumentNodeWithParent(createdDocument, parentDocument.getId());
 

--- a/src/test/java/goorm/eagle7/stelligence/domain/document/graph/DocumentGraphServiceTest.java
+++ b/src/test/java/goorm/eagle7/stelligence/domain/document/graph/DocumentGraphServiceTest.java
@@ -431,7 +431,7 @@ class DocumentGraphServiceTest {
 		}
 
 		//when
-		documentGraphService.updateDocumentTitle(updateTargetId, updateTitle);
+		documentGraphService.changeTitle(updateTargetId, updateTitle);
 
 		//then
 		DocumentNode documentNode = documentNodeRepository.findById(updateTargetId).get();
@@ -454,7 +454,7 @@ class DocumentGraphServiceTest {
 		}
 
 		//when
-		documentGraphService.updateDocumentTitle(updateTargetId, updateTitle);
+		documentGraphService.changeTitle(updateTargetId, updateTitle);
 
 		//then
 		DocumentNode documentNode = documentNodeRepository.findById(updateTargetId).get();
@@ -485,7 +485,7 @@ class DocumentGraphServiceTest {
 		DocumentNode targetDocumentNode = documentNodeRepository.findById(updateTargetId).get();
 		log.info("targetDocumentNode.getTitle(): {}", targetDocumentNode.getTitle());
 
-		documentGraphService.updateDocumentTitle(updateTargetId, updateTitle);
+		documentGraphService.changeTitle(updateTargetId, updateTitle);
 		log.info("업데이트 쿼리 안나간 것을 확인");
 
 		//then


### PR DESCRIPTION
## 변경 내용 

- 요구사항 변경에 따라 Document 엔티티에서 상위 문서를 참조하도록 변경되었습니다.
- @eenzzi 수정 요청사항에 대해서 보다 적절한 응답을 하도록 ContributeResponse를 수정하였습니다
- 수정요청이 병합될 때, 문서컨텐츠와 문서그래프 모두에서 제목과 상위문서 변경이 반영되도록 하였습니다.

## 특이 사항

- Contribute / Document / DocumentGraph 등 많은 도메인에 걸친 부분이 수정되었습니다.
- 열심히 체크했지만, 부족한 부분이 많을 것 같습니다.
  - 꼼꼼하게 체크해서 빠진 부분 말씀 부탁드립니다.

## 체크리스트

- [x] PR 날리기 전에 main branch pull 받으셨나요?
- [x] application.properties 등 노출되지 않아야 하는 파일이 올라가지는 않았나요?
- [x] 다른 담당자 파일을 수정한 부분에 대해서 이야기 하셨나요?
- [x] 주석 "상세히" 다셨나요?
- [x] 제출하기 전에 테스트코드 돌려 보셨나요?

closes #
