### PR TITLE
202 중복된 제목 등록 및 변경 막기

### DIFF
--- a/src/main/java/goorm/eagle7/stelligence/domain/contribute/ContributeRepository.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/contribute/ContributeRepository.java
@@ -29,4 +29,19 @@ public interface ContributeRepository extends JpaRepository<Contribute, Long>, C
 	 * @return 존재 여부
 	 */
 	boolean existsByDocumentAndStatus(Document document, ContributeStatus status);
+
+	/**
+	 * 현재 투표중인 수정요청에 대해 특정 제목으로 변경하고자 하는 요청이 존재하는지 확인한다.
+	 * @param title 검증할 문서 제목
+	 * @return 존재 여부
+	 */
+	@Query("SELECT CASE WHEN COUNT(c) > 0 THEN TRUE ELSE FALSE END"
+		+ " FROM Contribute c"
+		+ " left join Debate d on d.contribute = c"
+		+ " WHERE c.afterDocumentTitle = :title"
+		+ " AND ("
+		+ " c.status = goorm.eagle7.stelligence.domain.contribute.model.ContributeStatus.VOTING"
+		+ " OR d.status = goorm.eagle7.stelligence.domain.debate.model.DebateStatus.OPEN"
+		+ " )")
+	boolean existsDuplicateRequestedDocumentTitle(String title);
 }

--- a/src/main/java/goorm/eagle7/stelligence/domain/contribute/ContributeRequestValidator.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/contribute/ContributeRequestValidator.java
@@ -39,6 +39,8 @@ public class ContributeRequestValidator {
 	 *     <li>document가 존재하지 않을 경우</li>
 	 *     <li>해당 document에 대한 투표중인 수정요청이 존재하는 경우</li>
 	 *     <li>수정하고자 하는 section들이 document에 존재하지 않을 경우</li>
+	 *     <li>수정하고자 하는 제목이 다른 문서와 중복되는 경우</li>
+	 *     <li>수정하고자 하는 제목에 대해 다른 수정요청이 해당 제목으로 변경을 요청중인 경우</li>
 	 *     <li>각각의 sectionId를 가진 amendmentRequest들이 creatingOrder가 중복되거나 순차적이지 않을 경우</li>
 	 * </ul>
 	 * </p>
@@ -73,6 +75,15 @@ public class ContributeRequestValidator {
 				}
 			}
 		);
+
+		//변경하고자 하는 제목이 다른 문서와 중복되는가
+		if (documentContentRepository.existsByTitle(request.getAfterDocumentTitle())) {
+			throw new BaseException("이미 해당 제목을 가진 문서가 존재합니다. title=" + request.getAfterDocumentTitle());
+		}
+
+		if (contributeRepository.existsDuplicateRequestedDocumentTitle(request.getAfterDocumentTitle())) {
+			throw new BaseException("해당 제목으로 변경을 요청중인 수정요청이 이미 존재합니다. title=" + request.getAfterDocumentTitle());
+		}
 
 		//각각의 sectionId를 가진 amendmentRequest들이 creatingOrder를 중복되지 않으면서 순차적인 값을 가지고 있는가
 		Map<Long, List<Integer>> sectionOrders = request.getAmendments().stream()

--- a/src/main/java/goorm/eagle7/stelligence/domain/document/DocumentRequestValidator.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/document/DocumentRequestValidator.java
@@ -1,0 +1,59 @@
+package goorm.eagle7.stelligence.domain.document;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import goorm.eagle7.stelligence.api.exception.BaseException;
+import goorm.eagle7.stelligence.domain.contribute.ContributeRepository;
+import goorm.eagle7.stelligence.domain.document.content.DocumentContentRepository;
+import goorm.eagle7.stelligence.domain.document.dto.DocumentCreateRequest;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * DocumentCreateRequest의 유효성을 검증하는 클래스입니다.
+ */
+@Component
+@RequiredArgsConstructor
+public class DocumentRequestValidator {
+
+	private final DocumentContentRepository documentContentRepository;
+	private final ContributeRepository contributeRepository;
+
+	/**
+	 * 문서 생성 요청의 유효성을 검증합니다.
+	 * <p>검증 실패 케이스
+	 * <ul>
+	 *     <li>제목이 null이거나 빈값인 경우</li>
+	 *     <li>내용이 null이거나 빈값인 경우</li>
+	 *     <li>제목이 이미 존재하는 경우</li>
+	 *     <li>수정하고자 하는 제목에 대해 다른 수정요청이 해당 제목으로 변경을 요청중인 경우</li>
+	 * </ul>
+	 * </p>
+	 * @throws BaseException 유효하지 않은 요청일 경우
+	 * @param request 수정요청 DTO
+	 */
+	@Transactional(readOnly = true)
+	public void validate(DocumentCreateRequest request) {
+
+		//문서의 제목이 null이나 빈값이 아닌가?
+		if (!StringUtils.hasText(request.getTitle())) {
+			throw new BaseException("문서의 제목이 비어있습니다.");
+		}
+
+		//문서의 내용이 null이나 빈값이 아닌가?
+		if (!StringUtils.hasText(request.getContent())) {
+			throw new BaseException("문서의 내용이 비어있습니다.");
+		}
+
+		// 생성하려는 제목이 기존 내용과 중복될 여지가 있는가
+		if (documentContentRepository.existsByTitle(request.getTitle())) {
+			throw new BaseException("이미 존재하는 제목입니다.");
+		}
+
+		if (contributeRepository.existsDuplicateRequestedDocumentTitle(request.getTitle())) {
+			throw new BaseException("이미 해당 제목으로 변경중인 수정요청이 존재합니다.");
+		}
+
+	}
+}

--- a/src/main/java/goorm/eagle7/stelligence/domain/document/DocumentService.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/document/DocumentService.java
@@ -33,6 +33,7 @@ public class DocumentService {
 	private final DocumentContentService documentContentService;
 	private final DocumentGraphService documentGraphService;
 	private final MemberRepository memberRepository;
+	private final DocumentRequestValidator documentRequestValidator;
 
 	/**
 	 * Document를 생성합니다.
@@ -44,6 +45,9 @@ public class DocumentService {
 	 */
 	@Transactional
 	public DocumentResponse createDocument(DocumentCreateRequest documentCreateRequest, Long loginMemberId) {
+
+		// DocumentCreateRequest의 유효성을 검증합니다.
+		documentRequestValidator.validate(documentCreateRequest);
 
 		Member author = memberRepository.findById(loginMemberId)
 			.orElseThrow(() -> new BaseException("존재하지 않는 사용자입니다. 사용자 ID : " + loginMemberId));

--- a/src/main/java/goorm/eagle7/stelligence/domain/document/content/DocumentContentRepository.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/document/content/DocumentContentRepository.java
@@ -53,4 +53,11 @@ public interface DocumentContentRepository extends JpaRepository<Document, Long>
 		+ "and c.status = goorm.eagle7.stelligence.domain.contribute.model.ContributeStatus.MERGED "
 		+ "order by m.nickname")
 	List<Member> findContributorsByDocumentId(Long documentId);
+
+	/**
+	 * 특정 제목을 가진 Document가 존재하는지 조회합니다.
+	 * @param title 조회할 Document의 제목
+	 * @return 존재 여부
+	 */
+	boolean existsByTitle(String title);
 }

--- a/src/test/java/goorm/eagle7/stelligence/domain/contribute/ContributeRepositoryTest.java
+++ b/src/test/java/goorm/eagle7/stelligence/domain/contribute/ContributeRepositoryTest.java
@@ -1,0 +1,36 @@
+package goorm.eagle7.stelligence.domain.contribute;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import goorm.eagle7.stelligence.config.mockdata.WithMockData;
+
+@DataJpaTest
+@WithMockData
+class ContributeRepositoryTest {
+
+	@Autowired
+	private ContributeRepository contributeRepository;
+
+	@Test
+	@DisplayName("특정 제목을 가진 투표중인 수정요청이 존재하는지 여부 확인")
+	void contributeDocumentTitleDuplicate() {
+
+		boolean isExist = contributeRepository.existsDuplicateRequestedDocumentTitle("new_title_2");
+
+		assertThat(isExist).isTrue();
+	}
+
+	@Test
+	@DisplayName("특정 제목을 가진 진행중인 토론이 존재하는지 여부 확인")
+	void debateDocumentTitleDuplicate() {
+
+		boolean isExist = contributeRepository.existsDuplicateRequestedDocumentTitle("new_title_3");
+
+		assertThat(isExist).isTrue();
+	}
+}

--- a/src/test/java/goorm/eagle7/stelligence/domain/debate/repository/DebateRepositoryTest.java
+++ b/src/test/java/goorm/eagle7/stelligence/domain/debate/repository/DebateRepositoryTest.java
@@ -100,7 +100,7 @@ class DebateRepositoryTest {
 		List<Debate> debateList = debateRepository.findAllById(debateIdList);
 		assertThat(debateList)
 			.isNotEmpty()
-			.hasSize(3)
+			.hasSize(4)
 			.allMatch(d -> d.getStatus().equals(DebateStatus.OPEN))
 			.allMatch(d -> d.getEndAt().isBefore(LocalDateTime.now()));
 	}
@@ -117,7 +117,7 @@ class DebateRepositoryTest {
 		List<Debate> debateList = debateRepository.findAllById(debateIdList);
 		assertThat(debateList)
 			.isNotEmpty()
-			.hasSize(3)
+			.hasSize(4)
 			.allMatch(d -> d.getStatus().equals(DebateStatus.CLOSED));
 	}
 
@@ -134,7 +134,7 @@ class DebateRepositoryTest {
 		// then
 		assertThat(res1).isTrue();
 		assertThat(res2).isTrue();
-		assertThat(res3).isFalse();
+		assertThat(res3).isTrue();
 		assertThat(res4).isFalse();
 	}
 

--- a/src/test/java/goorm/eagle7/stelligence/domain/document/DocumentRequestValidatorTest.java
+++ b/src/test/java/goorm/eagle7/stelligence/domain/document/DocumentRequestValidatorTest.java
@@ -1,0 +1,96 @@
+package goorm.eagle7.stelligence.domain.document;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import goorm.eagle7.stelligence.api.exception.BaseException;
+import goorm.eagle7.stelligence.domain.contribute.ContributeRepository;
+import goorm.eagle7.stelligence.domain.document.content.DocumentContentRepository;
+import goorm.eagle7.stelligence.domain.document.dto.DocumentCreateRequest;
+
+@ExtendWith(MockitoExtension.class)
+class DocumentRequestValidatorTest {
+
+	@Mock
+	DocumentContentRepository documentContentRepository;
+
+	@Mock
+	ContributeRepository contributeRepository;
+
+	@InjectMocks
+	DocumentRequestValidator documentRequestValidator;
+
+	@Test
+	@DisplayName("제목이 null이거나 빈값인 경우")
+	void validateThrowsTitle() {
+		//given
+		DocumentCreateRequest request1 = DocumentCreateRequest.of(null, null, "content");
+		DocumentCreateRequest request2 = DocumentCreateRequest.of("  ", null, "content");
+
+		//then
+		assertThatThrownBy(
+			() -> documentRequestValidator.validate(request1))
+			.isInstanceOf(BaseException.class)
+			.hasMessage("문서의 제목이 비어있습니다.");
+
+		assertThatThrownBy(
+			() -> documentRequestValidator.validate(request2))
+			.isInstanceOf(BaseException.class)
+			.hasMessage("문서의 제목이 비어있습니다.");
+	}
+
+	@Test
+	@DisplayName("내용이 null이거나 빈값인 경우")
+	void validateThrowsContent() {
+		//given
+		DocumentCreateRequest request1 = DocumentCreateRequest.of("title", null, null);
+		DocumentCreateRequest request2 = DocumentCreateRequest.of("title", null, "           ");
+
+		//then
+		assertThatThrownBy(
+			() -> documentRequestValidator.validate(request1))
+			.isInstanceOf(BaseException.class)
+			.hasMessage("문서의 내용이 비어있습니다.");
+
+		assertThatThrownBy(
+			() -> documentRequestValidator.validate(request2))
+			.isInstanceOf(BaseException.class)
+			.hasMessage("문서의 내용이 비어있습니다.");
+	}
+
+	@Test
+	@DisplayName("제목이 이미 존재하는 경우")
+	void validateThrowsDuplicateTitle() {
+		//given
+		DocumentCreateRequest request = DocumentCreateRequest.of("title", null, "content");
+		when(documentContentRepository.existsByTitle("title")).thenReturn(true);
+
+		//then
+		assertThatThrownBy(
+			() -> documentRequestValidator.validate(request))
+			.isInstanceOf(BaseException.class)
+			.hasMessage("이미 존재하는 제목입니다.");
+	}
+
+	@Test
+	@DisplayName("수정하고자 하는 제목에 대해 다른 수정요청이 해당 제목으로 변경을 요청중인 경우")
+	void validateThrowsDuplicateRequestedDocumentTitle() {
+		//given
+		DocumentCreateRequest request = DocumentCreateRequest.of("title", null, "content");
+		when(documentContentRepository.existsByTitle("title")).thenReturn(false);
+		when(contributeRepository.existsDuplicateRequestedDocumentTitle("title")).thenReturn(true);
+
+		//then
+		assertThatThrownBy(
+			() -> documentRequestValidator.validate(request))
+			.isInstanceOf(BaseException.class)
+			.hasMessage("이미 해당 제목으로 변경중인 수정요청이 존재합니다.");
+	}
+}

--- a/src/test/java/goorm/eagle7/stelligence/domain/document/DocumentServiceTest.java
+++ b/src/test/java/goorm/eagle7/stelligence/domain/document/DocumentServiceTest.java
@@ -32,6 +32,9 @@ class DocumentServiceTest {
 	@Mock
 	private DocumentGraphService documentGraphService;
 
+	@Mock
+	private DocumentRequestValidator documentRequestValidator;
+
 	@InjectMocks
 	private DocumentService documentService;
 

--- a/src/test/resources/dummy.sql
+++ b/src/test/resources/dummy.sql
@@ -11,11 +11,11 @@ values (1, 'email1', 'name1', 'nickname1', 'USER', 0, 'image_url1', 'refresh_tok
         NOW(), 0);
 
 -- 4개의 문서가 존재합니다.
-insert into document (document_id, title, current_revision, created_at, updated_at)
-values (1, 'title1', 3, NOW(), NOW()),
-       (2, 'title2', 2, NOW(), NOW()),
-       (3, 'title3', 1, NOW(), NOW()),
-       (4, 'title4', 1, NOW(), NOW());
+insert into document (document_id, title, current_revision, parent_document_id, created_at, updated_at)
+values (1, 'title1', 3, null, NOW(), NOW()),
+       (2, 'title2', 2, null, NOW(), NOW()),
+       (3, 'title3', 1, null, NOW(), NOW()),
+       (4, 'title4', 1, null, NOW(), NOW());
 
 -- 14개의 섹션이 존재합니다.
 ------ 1번 문서에는 6개의 섹션이 존재합니다.
@@ -56,12 +56,16 @@ values ('section', 15);
 -- 5개의 contribute가 존재합니다.
 ------ 4번 Contribute는 5번 admentment를 갖고있는 수정요청으로, 거절되었습니다.
 ------ 5번은 6, 7번 admentment를 갖고 있는 수정요청으로, 투표중입니다.
-insert into contribute (contribute_id, member_id, document_id, title, description, status, created_at, updated_at)
-values (1, 1, 1, 'contribute_title1', 'contribute_description1', 'MERGED', '2024-03-21 00:00:00', NOW()),
-       (2, 2, 1, 'contribute_title2', 'contribute_description2', 'MERGED', '2024-03-21 00:01:00', NOW()),
-       (3, 3, 2, 'contribute_title3', 'contribute_description3', 'MERGED', '2024-03-21 00:02:00', NOW()),
-       (4, 1, 2, 'contribute_title4', 'contribute_description4', 'REJECTED', '2024-03-21 00:03:00', NOW()),
-       (5, 2, 2, 'contribute_title5', 'contribute_description5', 'VOTING', '2024-03-21 00:04:00', NOW());
+insert into contribute (contribute_id, member_id, document_id, title, description, status,
+                        before_document_title, after_document_title,
+                        before_parent_document_id, after_parent_document_id,
+                        created_at, updated_at)
+values (1, 1, 1, 'contribute_title1', 'contribute_description1', 'MERGED', 'title1', 'title1', null, null, '2024-03-21 00:00:00', NOW()),
+       (2, 2, 1, 'contribute_title2', 'contribute_description2', 'MERGED', 'title1', 'title1', null, null,'2024-03-21 00:01:00', NOW()),
+       (3, 3, 2, 'contribute_title3', 'contribute_description3', 'MERGED', 'title2', 'title2', null, null,'2024-03-21 00:02:00', NOW()),
+       (4, 1, 2, 'contribute_title4', 'contribute_description4', 'REJECTED', 'title2', 'title2', null, null, '2024-03-21 00:03:00', NOW()),
+       (5, 2, 2, 'contribute_title5', 'contribute_description5', 'VOTING', 'title2', 'new_title_2', null, null,'2024-03-21 00:04:00', NOW()),
+       (6, 1, 3, 'contribute_title6', 'contribute_description6', 'DEBATING', 'title3', 'new_title_3', null, null,'2024-03-21 00:05:00', NOW());
 
 
 -- 7개의 admentment가 존재합니다.
@@ -90,7 +94,8 @@ values (1, 1, 'OPEN', TIMESTAMPADD(HOUR, 1, NOW()), 1, NOW()),
        (3, 3, 'OPEN', TIMESTAMPADD(MINUTE, -1, NOW()), 1, NOW()),
        (4, 4, 'CLOSED', NOW(), 1, NOW()),
        (5, 5, 'CLOSED', NOW(), 1, NOW()),
-       (6, 5, 'OPEN', NOW(), 1, NOW());
+       (6, 5, 'OPEN', NOW(), 1, NOW()),
+       (7, 6, 'OPEN', NOW(), 1, NOW());
 
 insert into comment (comment_id, debate_id, commenter_id, content, sequences, created_at)
 values (1, 1, 1, '댓글1', 1, TIMESTAMPADD(HOUR, -3, NOW())),


### PR DESCRIPTION
## 변경 내용 

- 이제는 애플리케이션 단에서 문서의 제목이 중복되는 것을 막습니다.
  - 다음과 같은 검증 메서드가 추가되었습니다.
    -  이미 해당 제목을 가진 문서가 존재하는가
    -  수정요청에서 해당 제목으로 변경하고자 하는 요청이 존재하는가
  - 수정요청을 등록하는 시점에서 ContributeRequestValidator는 위 두 내용을 검증합니다.
  - 글을 생성하는 시점에서 DocumentRequestValidator는 위 두 내용을 검증합니다.
  - 테스트코드 반영하였습니다.

## 특이 사항

- 

## 체크리스트

- [x] PR 날리기 전에 main branch pull 받으셨나요?
- [x] application.properties 등 노출되지 않아야 하는 파일이 올라가지는 않았나요?
- [x] 다른 담당자 파일을 수정한 부분에 대해서 이야기 하셨나요?
- [x] 주석 "상세히" 다셨나요?
- [x] 제출하기 전에 테스트코드 돌려 보셨나요?

closes #202 
