### PR TITLE
202-문서-제목-중복-해결

### DIFF
--- a/src/main/java/goorm/eagle7/stelligence/config/SwaggerConfig.java
+++ b/src/main/java/goorm/eagle7/stelligence/config/SwaggerConfig.java
@@ -13,7 +13,8 @@ import io.swagger.v3.oas.models.OpenAPI;
  */
 @OpenAPIDefinition(
 	servers = {
-		@Server(url = "https://api.stelligence.site/", description = "Default Server URL")
+		@Server(url = "https://api.stelligence.site/", description = "Default Server URL"),
+		@Server(url = "http://localhost:8080/", description = "Local Server URL")
 	}
 )
 @Configuration

--- a/src/main/java/goorm/eagle7/stelligence/domain/contribute/ContributeRequestValidator.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/contribute/ContributeRequestValidator.java
@@ -4,6 +4,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -77,7 +78,10 @@ public class ContributeRequestValidator {
 		);
 
 		//변경하고자 하는 제목이 다른 문서와 중복되는가
-		if (documentContentRepository.existsByTitle(request.getAfterDocumentTitle())) {
+
+		//이미 제목을 가진 문서가 존재하는가 - contribute의 대상이 되는 document라면 허용
+		Optional<Document> optionalDocument = documentContentRepository.findByTitle(request.getAfterDocumentTitle());
+		if (optionalDocument.isPresent() && !optionalDocument.get().getId().equals(request.getDocumentId())) {
 			throw new BaseException("이미 해당 제목을 가진 문서가 존재합니다. title=" + request.getAfterDocumentTitle());
 		}
 

--- a/src/main/java/goorm/eagle7/stelligence/domain/document/content/DocumentContentRepository.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/document/content/DocumentContentRepository.java
@@ -55,6 +55,14 @@ public interface DocumentContentRepository extends JpaRepository<Document, Long>
 	List<Member> findContributorsByDocumentId(Long documentId);
 
 	/**
+	 * 특정 제목을 가진 Document를 조회합니다.
+	 * 애플리케이션 로직 상 제목은 유일해야 합니다.
+	 * @param title 조회할 Document의 제목
+	 * @return 존재 여부
+	 */
+	Optional<Document> findByTitle(String title);
+
+	/**
 	 * 특정 제목을 가진 Document가 존재하는지 조회합니다.
 	 * @param title 조회할 Document의 제목
 	 * @return 존재 여부

--- a/src/test/java/goorm/eagle7/stelligence/domain/contribute/ContributeRequestValidatorTest.java
+++ b/src/test/java/goorm/eagle7/stelligence/domain/contribute/ContributeRequestValidatorTest.java
@@ -1,5 +1,6 @@
 package goorm.eagle7.stelligence.domain.contribute;
 
+import static goorm.eagle7.stelligence.config.mockdata.TestFixtureGenerator.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -39,6 +40,8 @@ class ContributeRequestValidatorTest {
 	@DisplayName("검증 성공케이스")
 	void validateSuccess() {
 
+		Document targetDocument = document(1L, member(1L, "pete"), "title", 1L, null);
+
 		AmendmentRequest a1 = new AmendmentRequest(1L, AmendmentType.DELETE, Heading.H2, "title",
 			"content", 0);
 		AmendmentRequest a2 = new AmendmentRequest(1L, AmendmentType.CREATE, Heading.H2, "title",
@@ -59,7 +62,7 @@ class ContributeRequestValidatorTest {
 		when(documentContentRepository.findById(1L)).thenReturn(Optional.of(mock(Document.class)));
 		when(contributeRepository.existsByDocumentAndStatus(any(), any())).thenReturn(false);
 		when(sectionRepository.findSectionIdByVersion(any(), any())).thenReturn(List.of(1L, 2L, 3L));
-		when(documentContentRepository.existsByTitle("title")).thenReturn(false);
+		when(documentContentRepository.findByTitle("title")).thenReturn(Optional.of(targetDocument));
 		when(contributeRepository.existsDuplicateRequestedDocumentTitle("title")).thenReturn(false);
 
 		//then
@@ -118,6 +121,8 @@ class ContributeRequestValidatorTest {
 	@Test
 	@DisplayName("변경할 title이 중복되는 경우 - 이미 존재하는 문서 제목")
 	void duplicateDocumentTitle() {
+		Document targetDocument = document(3L, member(1L, "pete"), "newTitle", 1L, null);
+
 		ContributeRequest contributeRequest = new ContributeRequest("title", "description", Collections.emptyList(), 1L,
 			"newTitle", 2L);
 
@@ -125,7 +130,7 @@ class ContributeRequestValidatorTest {
 		when(documentContentRepository.findById(1L)).thenReturn(Optional.of(mock(Document.class)));
 		when(contributeRepository.existsByDocumentAndStatus(any(), any())).thenReturn(false);
 		when(sectionRepository.findSectionIdByVersion(any(), any())).thenReturn(Collections.emptyList());
-		when(documentContentRepository.existsByTitle("newTitle")).thenReturn(true);
+		when(documentContentRepository.findByTitle("newTitle")).thenReturn(Optional.of(targetDocument));
 
 		assertThatThrownBy(
 			() -> contributeRequestValidator.validate(contributeRequest)
@@ -143,7 +148,7 @@ class ContributeRequestValidatorTest {
 		when(documentContentRepository.findById(1L)).thenReturn(Optional.of(mock(Document.class)));
 		when(contributeRepository.existsByDocumentAndStatus(any(), any())).thenReturn(false);
 		when(sectionRepository.findSectionIdByVersion(any(), any())).thenReturn(Collections.emptyList());
-		when(documentContentRepository.existsByTitle("newTitle")).thenReturn(false);
+		when(documentContentRepository.findByTitle("newTitle")).thenReturn(Optional.empty());
 		when(contributeRepository.existsDuplicateRequestedDocumentTitle("newTitle")).thenReturn(true);
 
 		assertThatThrownBy(


### PR DESCRIPTION
## 변경 내용 

- Contribute 생성 시 변경하고자하는 문서의 제목을 바꾸지 않았을 때, exist의 결과를 문서 제목의 중복이라고 판단하여 에러를 발생시키던 문제를 해결

## 특이 사항

- 

## 체크리스트

- [x] PR 날리기 전에 main branch pull 받으셨나요?
- [x] application.properties 등 노출되지 않아야 하는 파일이 올라가지는 않았나요?
- [x] 다른 담당자 파일을 수정한 부분에 대해서 이야기 하셨나요?
- [x] 주석 "상세히" 다셨나요?
- [x] 제출하기 전에 테스트코드 돌려 보셨나요?

closes #202 
