### PR TITLE
216 문서 상세 조회 시 상위문서태그와 투표중 토론중 토론수정대기중 상태 반환

### DIFF
--- a/src/main/java/goorm/eagle7/stelligence/domain/contribute/custom/CustomContributeRepository.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/contribute/custom/CustomContributeRepository.java
@@ -7,7 +7,6 @@ import org.springframework.data.domain.Pageable;
 
 import goorm.eagle7.stelligence.domain.contribute.model.Contribute;
 import goorm.eagle7.stelligence.domain.contribute.model.ContributeStatus;
-import goorm.eagle7.stelligence.domain.document.content.model.Document;
 
 public interface CustomContributeRepository {
 
@@ -17,5 +16,5 @@ public interface CustomContributeRepository {
 
 	Page<Contribute> findByDocumentAndStatus(Long documentId, boolean merged, Pageable pageable);
 
-	Optional<Contribute> findLatestContributeByDocument(Document document);
+	Optional<Contribute> findLatestContributeByDocumentId(Long documentId);
 }

--- a/src/main/java/goorm/eagle7/stelligence/domain/contribute/custom/CustomContributeRepository.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/contribute/custom/CustomContributeRepository.java
@@ -1,10 +1,13 @@
 package goorm.eagle7.stelligence.domain.contribute.custom;
 
+import java.util.Optional;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import goorm.eagle7.stelligence.domain.contribute.model.Contribute;
 import goorm.eagle7.stelligence.domain.contribute.model.ContributeStatus;
+import goorm.eagle7.stelligence.domain.document.content.model.Document;
 
 public interface CustomContributeRepository {
 
@@ -13,4 +16,6 @@ public interface CustomContributeRepository {
 	Page<Contribute> findCompleteContributes(Pageable pageable);
 
 	Page<Contribute> findByDocumentAndStatus(Long documentId, boolean merged, Pageable pageable);
+
+	Optional<Contribute> findLatestContributeByDocument(Document document);
 }

--- a/src/main/java/goorm/eagle7/stelligence/domain/contribute/custom/CustomContributeRepositoryImpl.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/contribute/custom/CustomContributeRepositoryImpl.java
@@ -1,6 +1,7 @@
 package goorm.eagle7.stelligence.domain.contribute.custom;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -13,6 +14,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import goorm.eagle7.stelligence.domain.contribute.model.Contribute;
 import goorm.eagle7.stelligence.domain.contribute.model.ContributeStatus;
 import goorm.eagle7.stelligence.domain.contribute.model.QContribute;
+import goorm.eagle7.stelligence.domain.document.content.model.Document;
 import jakarta.persistence.EntityManager;
 
 public class CustomContributeRepositoryImpl implements CustomContributeRepository {
@@ -86,5 +88,19 @@ public class CustomContributeRepositoryImpl implements CustomContributeRepositor
 		}
 
 		return findContributesByCondition(builder, pageable);
+	}
+
+	@Override
+	public Optional<Contribute> findLatestContributeByDocument(Document document) {
+		QContribute contribute = QContribute.contribute;
+
+		Contribute findContribute = queryFactory
+			.selectFrom(contribute)
+			.where(contribute.document.eq(document))
+			.orderBy(contribute.createdAt.desc())
+			.limit(1)
+			.fetchOne();
+
+		return Optional.ofNullable(findContribute);
 	}
 }

--- a/src/main/java/goorm/eagle7/stelligence/domain/contribute/custom/CustomContributeRepositoryImpl.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/contribute/custom/CustomContributeRepositoryImpl.java
@@ -14,7 +14,6 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import goorm.eagle7.stelligence.domain.contribute.model.Contribute;
 import goorm.eagle7.stelligence.domain.contribute.model.ContributeStatus;
 import goorm.eagle7.stelligence.domain.contribute.model.QContribute;
-import goorm.eagle7.stelligence.domain.document.content.model.Document;
 import jakarta.persistence.EntityManager;
 
 public class CustomContributeRepositoryImpl implements CustomContributeRepository {
@@ -91,12 +90,12 @@ public class CustomContributeRepositoryImpl implements CustomContributeRepositor
 	}
 
 	@Override
-	public Optional<Contribute> findLatestContributeByDocument(Document document) {
+	public Optional<Contribute> findLatestContributeByDocumentId(Long documentId) {
 		QContribute contribute = QContribute.contribute;
 
 		Contribute findContribute = queryFactory
 			.selectFrom(contribute)
-			.where(contribute.document.eq(document))
+			.where(contribute.document.id.eq(documentId))
 			.orderBy(contribute.createdAt.desc())
 			.limit(1)
 			.fetchOne();

--- a/src/main/java/goorm/eagle7/stelligence/domain/debate/model/Debate.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/debate/model/Debate.java
@@ -100,4 +100,16 @@ public class Debate extends BaseTimeEntity {
 			.map(c -> c.getCommenter().getId())
 			.anyMatch(commenterId -> commenterId.equals(memberId));
 	}
+
+	// 토론 중인지를 확인
+	public boolean isOnDebate() {
+		return this.status.equals(DebateStatus.OPEN);
+	}
+
+	// 토론이 끝난 후 수정요청 대기중인지를 확인
+	public boolean isPendingForContribute() {
+		// 토론이 끝난 후 DEBATE_PENDING_DURATION_MINUTE 분 동안 수정요청 대기상태
+		LocalDateTime pendingLimitTime = this.endAt.plusMinutes(DEBATE_PENDING_DURATION_MINUTE);
+		return this.status.equals(DebateStatus.CLOSED) && pendingLimitTime.isAfter(LocalDateTime.now());
+	}
 }

--- a/src/main/java/goorm/eagle7/stelligence/domain/debate/model/Debate.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/debate/model/Debate.java
@@ -93,4 +93,11 @@ public class Debate extends BaseTimeEntity {
 	public int getAndIncrementCommentSequence() {
 		return commentSequence++;
 	}
+
+	public boolean hasPermissionToWriteDrivenContribute(Long memberId) {
+		return comments
+			.stream()
+			.map(c -> c.getCommenter().getId())
+			.anyMatch(commenterId -> commenterId.equals(memberId));
+	}
 }

--- a/src/main/java/goorm/eagle7/stelligence/domain/debate/model/Debate.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/debate/model/Debate.java
@@ -29,6 +29,13 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class Debate extends BaseTimeEntity {
 
+	//토론 연장 지속 시간: 60분 * 24시간 = 1일
+	public static final Long DEBATE_EXTENSION_DURATION_MINUTE = 60L * 24L;
+	//토론 최대 지속 시간: 60분 * 24시간 * 7일 = 7일
+	public static final Long DEBATE_LIMIT_DURATION_MINUTE = 60L * 24L * 7L;
+	//토론 이후 수정요청 대기 시간: 60분 * 24시간 = 1일
+	public static final Long DEBATE_PENDING_DURATION_MINUTE = 60L * 24L;
+
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "debate_id")
@@ -55,7 +62,7 @@ public class Debate extends BaseTimeEntity {
 		contribute.setStatusDebating();
 		this.contribute = contribute;
 		this.status = DebateStatus.OPEN;
-		this.endAt = LocalDateTime.now().plusDays(1L);
+		this.endAt = LocalDateTime.now().plusMinutes(DEBATE_EXTENSION_DURATION_MINUTE);
 		this.commentSequence = 1;
 	}
 
@@ -69,11 +76,11 @@ public class Debate extends BaseTimeEntity {
 
 	/**
 	 * 댓글이 업데이트 될때, 토론 종료시간도 업데이트됩니다.
-	 * 단, 토론을 유지할 수 있는 최대 기간은 7일입니다.
+	 * 단, 토론을 유지할 수 있는 최대 기간은 {@link #DEBATE_LIMIT_DURATION_MINUTE}분 입니다.
 	 */
 	public void updateEndAt() {
-		LocalDateTime extendEndAt = LocalDateTime.now().plusDays(1L);
-		LocalDateTime limitEndAt = this.createdAt.plusDays(7L);
+		LocalDateTime extendEndAt = LocalDateTime.now().plusMinutes(DEBATE_EXTENSION_DURATION_MINUTE);
+		LocalDateTime limitEndAt = this.createdAt.plusMinutes(DEBATE_LIMIT_DURATION_MINUTE);
 
 		if (extendEndAt.isBefore(limitEndAt)) {
 			this.endAt = extendEndAt;

--- a/src/main/java/goorm/eagle7/stelligence/domain/debate/repository/CustomDebateRepository.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/debate/repository/CustomDebateRepository.java
@@ -1,5 +1,7 @@
 package goorm.eagle7.stelligence.domain.debate.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -11,4 +13,6 @@ public interface CustomDebateRepository {
 
 	Page<Debate> findPageByStatusAndOrderCondition(
 		DebateStatus status, DebateOrderCondition orderCondition, Pageable pageable);
+
+	Optional<Debate> findLatestDebateByDocumentId(Long documentId);
 }

--- a/src/main/java/goorm/eagle7/stelligence/domain/debate/repository/CustomDebateRepositoryImpl.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/debate/repository/CustomDebateRepositoryImpl.java
@@ -35,15 +35,15 @@ public class CustomDebateRepositoryImpl implements CustomDebateRepository {
 	@Override
 	public Optional<Debate> findLatestDebateByDocumentId(Long documentId) {
 
-		Debate findDebate = em.createQuery(
+		List<Debate> debates = em.createQuery(
 				"select d from Debate d"
 					+ " where d.contribute.document.id = :documentId"
 					+ " order by d.createdAt desc", Debate.class)
 			.setParameter("documentId", documentId)
 			.setMaxResults(1)
-			.getSingleResult();
+			.getResultList();
 
-		return Optional.ofNullable(findDebate);
+		return debates.stream().findFirst();
 	}
 
 	private Page<Debate> findPageByStatusOrderByLatest(DebateStatus status, Pageable pageable) {

--- a/src/main/java/goorm/eagle7/stelligence/domain/debate/repository/CustomDebateRepositoryImpl.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/debate/repository/CustomDebateRepositoryImpl.java
@@ -1,6 +1,7 @@
 package goorm.eagle7.stelligence.domain.debate.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -29,6 +30,20 @@ public class CustomDebateRepositoryImpl implements CustomDebateRepository {
 			case RECENT_COMMENTED -> findPageByStatusOrderByRecentComment(status, pageable);
 		};
 
+	}
+
+	@Override
+	public Optional<Debate> findLatestDebateByDocumentId(Long documentId) {
+
+		Debate findDebate = em.createQuery(
+				"select d from Debate d"
+					+ " where d.contribute.document.id = :documentId"
+					+ " order by d.createdAt desc", Debate.class)
+			.setParameter("documentId", documentId)
+			.setMaxResults(1)
+			.getSingleResult();
+
+		return Optional.ofNullable(findDebate);
 	}
 
 	private Page<Debate> findPageByStatusOrderByLatest(DebateStatus status, Pageable pageable) {

--- a/src/main/java/goorm/eagle7/stelligence/domain/document/DocumentService.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/document/DocumentService.java
@@ -73,7 +73,8 @@ public class DocumentService {
 		 * 추후에 코드가 변경될 여지가 있습니다. 자세한 내용은 Document.sections의 주석을 참고해주세요.
 		 */
 		List<SectionResponse> sections = createdDocument.getSections().stream().map(SectionResponse::of).toList();
-		return DocumentResponse.of(createdDocument, 1L, sections, Collections.emptyList(), true);
+		return DocumentResponse.of(
+			createdDocument, 1L, sections, Collections.emptyList(), null, null);
 	}
 
 	/**

--- a/src/main/java/goorm/eagle7/stelligence/domain/document/content/DocumentContentService.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/document/content/DocumentContentService.java
@@ -128,7 +128,7 @@ public class DocumentContentService {
 		boolean isDebating = debateRepository.existsByContributeDocumentIdAndStatus(documentId, DebateStatus.OPEN);
 		boolean isEditable = !isVoting && !isDebating;
 
-		Contribute latestContribute = contributeRepository.findLatestContributeByDocument(document).orElse(null);
+		Contribute latestContribute = contributeRepository.findLatestContributeByDocumentId(document.getId()).orElse(null);
 		Debate latestDebate = debateRepository.findLatestDebateByDocumentId(document.getId()).orElse(null);
 
 		return DocumentResponse.of(document, revision, sections, contributors, isEditable);

--- a/src/main/java/goorm/eagle7/stelligence/domain/document/content/DocumentContentService.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/document/content/DocumentContentService.java
@@ -131,7 +131,7 @@ public class DocumentContentService {
 		Contribute latestContribute = contributeRepository.findLatestContributeByDocumentId(document.getId()).orElse(null);
 		Debate latestDebate = debateRepository.findLatestDebateByDocumentId(document.getId()).orElse(null);
 
-		return DocumentResponse.of(document, revision, sections, contributors, isEditable);
+		return DocumentResponse.of(document, revision, sections, contributors, latestContribute, latestDebate);
 	}
 
 	/**

--- a/src/main/java/goorm/eagle7/stelligence/domain/document/content/DocumentContentService.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/document/content/DocumentContentService.java
@@ -10,9 +10,7 @@ import goorm.eagle7.stelligence.api.exception.BaseException;
 import goorm.eagle7.stelligence.common.sequence.SectionIdGenerator;
 import goorm.eagle7.stelligence.domain.contribute.ContributeRepository;
 import goorm.eagle7.stelligence.domain.contribute.model.Contribute;
-import goorm.eagle7.stelligence.domain.contribute.model.ContributeStatus;
 import goorm.eagle7.stelligence.domain.debate.model.Debate;
-import goorm.eagle7.stelligence.domain.debate.model.DebateStatus;
 import goorm.eagle7.stelligence.domain.debate.repository.DebateRepository;
 import goorm.eagle7.stelligence.domain.document.content.dto.DocumentResponse;
 import goorm.eagle7.stelligence.domain.document.content.dto.SectionRequest;
@@ -121,12 +119,6 @@ public class DocumentContentService {
 			.stream()
 			.map(MemberSimpleResponse::from)
 			.toList();
-
-		// 수정 가능 여부를 판별
-		// 정확히는 토론 종료 후 1일 동안은 기본적으로 불가능하며, 토론자에게만 수정요청을 받을 수 있도록 만들어야 합니다.
-		boolean isVoting = contributeRepository.existsByDocumentAndStatus(document, ContributeStatus.VOTING);
-		boolean isDebating = debateRepository.existsByContributeDocumentIdAndStatus(documentId, DebateStatus.OPEN);
-		boolean isEditable = !isVoting && !isDebating;
 
 		Contribute latestContribute = contributeRepository.findLatestContributeByDocumentId(document.getId()).orElse(null);
 		Debate latestDebate = debateRepository.findLatestDebateByDocumentId(document.getId()).orElse(null);

--- a/src/main/java/goorm/eagle7/stelligence/domain/document/content/DocumentContentService.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/document/content/DocumentContentService.java
@@ -9,7 +9,9 @@ import org.springframework.transaction.annotation.Transactional;
 import goorm.eagle7.stelligence.api.exception.BaseException;
 import goorm.eagle7.stelligence.common.sequence.SectionIdGenerator;
 import goorm.eagle7.stelligence.domain.contribute.ContributeRepository;
+import goorm.eagle7.stelligence.domain.contribute.model.Contribute;
 import goorm.eagle7.stelligence.domain.contribute.model.ContributeStatus;
+import goorm.eagle7.stelligence.domain.debate.model.Debate;
 import goorm.eagle7.stelligence.domain.debate.model.DebateStatus;
 import goorm.eagle7.stelligence.domain.debate.repository.DebateRepository;
 import goorm.eagle7.stelligence.domain.document.content.dto.DocumentResponse;
@@ -125,6 +127,9 @@ public class DocumentContentService {
 		boolean isVoting = contributeRepository.existsByDocumentAndStatus(document, ContributeStatus.VOTING);
 		boolean isDebating = debateRepository.existsByContributeDocumentIdAndStatus(documentId, DebateStatus.OPEN);
 		boolean isEditable = !isVoting && !isDebating;
+
+		Contribute latestContribute = contributeRepository.findLatestContributeByDocument(document).orElse(null);
+		Debate latestDebate = debateRepository.findLatestDebateByDocumentId(document.getId()).orElse(null);
 
 		return DocumentResponse.of(document, revision, sections, contributors, isEditable);
 	}

--- a/src/main/java/goorm/eagle7/stelligence/domain/document/content/dto/DocumentResponse.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/document/content/dto/DocumentResponse.java
@@ -99,7 +99,7 @@ public class DocumentResponse {
 
 		public static DocumentStatusInfo of(Contribute latestContribute, Debate latestDebate) {
 			if (latestContribute != null && latestContribute.isVoting()) {
-				return new DocumentStatusInfo(DocumentStatus.VOTING, latestDebate.getId(), null);
+				return new DocumentStatusInfo(DocumentStatus.VOTING, latestContribute.getId(), null);
 			} else if (latestDebate != null && latestDebate.isOnDebate()) {
 				return new DocumentStatusInfo(DocumentStatus.DEBATING, null, latestDebate.getId());
 			} else if (latestDebate != null && latestDebate.isPendingForContribute()) {

--- a/src/main/java/goorm/eagle7/stelligence/domain/document/content/dto/DocumentResponse.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/document/content/dto/DocumentResponse.java
@@ -25,6 +25,9 @@ public class DocumentResponse {
 	private Long documentId;
 	private String title;
 
+	private Long parentDocumentId;
+	private String parentDocumentTitle;
+
 	private Long latestRevision;
 	private Long currentRevision;
 
@@ -73,6 +76,8 @@ public class DocumentResponse {
 		return new DocumentResponse(
 			document.getId(),
 			document.getTitle(),
+			document.getParentDocument() == null ? null : document.getParentDocument().getId(),
+			document.getParentDocument() == null ? null : document.getParentDocument().getTitle(),
 			document.getLatestRevision(),
 			currentRevision,
 			document.getUpdatedAt(),

--- a/src/main/java/goorm/eagle7/stelligence/domain/document/content/dto/DocumentResponse.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/document/content/dto/DocumentResponse.java
@@ -3,6 +3,8 @@ package goorm.eagle7.stelligence.domain.document.content.dto;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import goorm.eagle7.stelligence.domain.contribute.model.Contribute;
+import goorm.eagle7.stelligence.domain.debate.model.Debate;
 import goorm.eagle7.stelligence.domain.document.content.model.Document;
 import goorm.eagle7.stelligence.domain.document.content.parser.SectionResponseConcatenator;
 import goorm.eagle7.stelligence.domain.member.dto.MemberSimpleResponse;
@@ -45,11 +47,9 @@ public class DocumentResponse {
 
 	private List<MemberSimpleResponse> contributors;
 
-	/**
-	 * 사용자가 글을 수정할 수 있는지 여부입니다.
-	 * 투표 중 혹은 토론 종료 1일 전까지는 수정이 제한됩니다.
-	 */
-	private boolean isEditable;
+	private DocumentStatus documentStatus;	//문서 상태(편집가능, 투표중, 토론중, 토론참여자 대상 수정대기중)
+	private Long contributeId;	//투표중인 상태일때 수정요청 정보
+	private Long debateId;	//토론중, 토론참여자 수정대기중인 상태에서의 토론 정보
 
 	/**
 	 * DocumentResponse를 생성합니다.
@@ -65,8 +65,11 @@ public class DocumentResponse {
 		Long currentRevision,
 		List<SectionResponse> sections,
 		List<MemberSimpleResponse> contributors,
-		boolean isEditable
+		Contribute latestContribute,
+		Debate latestDebate
 	) {
+		DocumentStatusInfo documentStatusInfo = DocumentStatusInfo.of(latestContribute, latestDebate);
+
 		return new DocumentResponse(
 			document.getId(),
 			document.getTitle(),
@@ -77,8 +80,34 @@ public class DocumentResponse {
 			SectionResponseConcatenator.concat(sections),
 			MemberSimpleResponse.from(document.getAuthor()),
 			contributors,
-			isEditable
+			documentStatusInfo.getDocumentStatus(),
+			documentStatusInfo.getContributeId(),
+			documentStatusInfo.getDebateId()
+
 		);
+	}
+
+	/**
+	 * DocumentStatus와 관련된 정보를 처리하는 내부 정적 클래스입니다.
+	 */
+	@AllArgsConstructor(access = AccessLevel.PRIVATE)
+	@Getter
+	private static class DocumentStatusInfo {
+		private DocumentStatus documentStatus;	//문서 상태(편집가능, 투표중, 토론중, 토론참여자 수정대기중)
+		private Long contributeId;	//투표중인 상태일때 수정요청 정보
+		private Long debateId;	//토론중, 토론참여자 수정대기중인 상태에서의 토론 정보
+
+		public static DocumentStatusInfo of(Contribute latestContribute, Debate latestDebate) {
+			if (latestContribute != null && latestContribute.isVoting()) {
+				return new DocumentStatusInfo(DocumentStatus.VOTING, latestDebate.getId(), null);
+			} else if (latestDebate != null && latestDebate.isOnDebate()) {
+				return new DocumentStatusInfo(DocumentStatus.DEBATING, null, latestDebate.getId());
+			} else if (latestDebate != null && latestDebate.isPendingForContribute()) {
+				return new DocumentStatusInfo(DocumentStatus.PENDING, null, latestDebate.getId());
+			} else {
+				return new DocumentStatusInfo(DocumentStatus.EDITABLE, null, null);
+			}
+		}
 	}
 
 }

--- a/src/main/java/goorm/eagle7/stelligence/domain/document/content/dto/DocumentStatus.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/document/content/dto/DocumentStatus.java
@@ -1,0 +1,9 @@
+package goorm.eagle7.stelligence.domain.document.content.dto;
+
+public enum DocumentStatus {
+
+	EDITABLE,	//편집 가능
+	VOTING,	//투표중
+	DEBATING,	//토론중
+	PENDING	//토론 종료 후 토론 참여자의 수정 요청 대기중
+}

--- a/src/test/java/goorm/eagle7/stelligence/domain/debate/model/DebateTest.java
+++ b/src/test/java/goorm/eagle7/stelligence/domain/debate/model/DebateTest.java
@@ -1,0 +1,42 @@
+package goorm.eagle7.stelligence.domain.debate.model;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import goorm.eagle7.stelligence.config.mockdata.TestFixtureGenerator;
+import goorm.eagle7.stelligence.domain.member.model.Member;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+class DebateTest {
+
+	@Test
+	@DisplayName("토론기반 수정요청 작성 권한 검증 테스트")
+	void hasPermissionToWriteDrivenContribute() {
+		//given
+		Member commenter1 = TestFixtureGenerator.member(1L, "댓글작성자1");
+		Member commenter2 = TestFixtureGenerator.member(2L, "댓글작성자2");
+		Member noCommenter = TestFixtureGenerator.member(3L, "댓글 작성안한 회원");
+
+		Debate debate = TestFixtureGenerator.debate(
+			1L, null, DebateStatus.CLOSED, LocalDateTime.now(), 1, LocalDateTime.now());
+		Comment comment1 = Comment.createComment("댓글1", debate, commenter1);
+		Comment comment2 = Comment.createComment("댓글1", debate, commenter2);
+
+		//when
+		boolean commenter1HasPermission = debate.hasPermissionToWriteDrivenContribute(commenter1.getId());
+		boolean commenter2HasPermission = debate.hasPermissionToWriteDrivenContribute(commenter2.getId());
+		boolean noCommenterHasPermission = debate.hasPermissionToWriteDrivenContribute(noCommenter.getId());
+		log.info("댓글작성자 목록: {}", debate.getComments()
+			.stream().map(c -> c.getCommenter().getNickname()).toList());
+
+		//then
+		assertThat(commenter1HasPermission).isTrue();
+		assertThat(commenter2HasPermission).isTrue();
+		assertThat(noCommenterHasPermission).isFalse();
+	}
+}

--- a/src/test/java/goorm/eagle7/stelligence/domain/debate/model/DebateTest.java
+++ b/src/test/java/goorm/eagle7/stelligence/domain/debate/model/DebateTest.java
@@ -39,4 +39,48 @@ class DebateTest {
 		assertThat(commenter2HasPermission).isTrue();
 		assertThat(noCommenterHasPermission).isFalse();
 	}
+
+	@Test
+	@DisplayName("토론중인지를 확인")
+	void onDebate() {
+		//given
+		Debate openDebate = TestFixtureGenerator.debate(
+			1L, null, DebateStatus.OPEN, LocalDateTime.now().plusDays(1L), 1, LocalDateTime.now());
+		Debate closedDebate = TestFixtureGenerator.debate(
+			1L, null, DebateStatus.CLOSED, LocalDateTime.now(), 1, LocalDateTime.now());
+
+		//when
+
+		//then
+		assertThat(openDebate.isOnDebate()).isTrue();
+		assertThat(closedDebate.isOnDebate()).isFalse();
+	}
+
+	@Test
+	@DisplayName("토론이 끝난 후 수정요청 대기중인지를 확인")
+	void pendingForContribute() {
+		//given
+		Debate openDebate = TestFixtureGenerator.debate(
+			1L, null, DebateStatus.OPEN, LocalDateTime.now().plusDays(1L), 1, LocalDateTime.now());
+		Debate closedDebateLongTimeAgo = TestFixtureGenerator.debate(
+			1L,
+			null,
+			DebateStatus.CLOSED,
+			LocalDateTime.now().minusMinutes(Debate.DEBATE_PENDING_DURATION_MINUTE).minusMinutes(1L),
+			1,
+			LocalDateTime.now());
+		Debate closedDebateRightNow = TestFixtureGenerator.debate(
+			1L, null, DebateStatus.CLOSED, LocalDateTime.now(), 1, LocalDateTime.now());
+
+		//when
+
+		//then
+
+		//열린 토론은 수정 요청 대기중이 아님
+		assertThat(openDebate.isPendingForContribute()).isFalse();
+		//오래전에 닫힌 토론은 수정요청 대기중이 아님
+		assertThat(closedDebateLongTimeAgo.isPendingForContribute()).isFalse();
+		//닫힌지 얼마 되지 않은 토론은 수정요청 대기중임
+		assertThat(closedDebateRightNow.isPendingForContribute()).isTrue();
+	}
 }

--- a/src/test/java/goorm/eagle7/stelligence/domain/debate/repository/DebateRepositoryTest.java
+++ b/src/test/java/goorm/eagle7/stelligence/domain/debate/repository/DebateRepositoryTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.*;
 import java.time.LocalDateTime;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import org.junit.jupiter.api.DisplayName;
@@ -138,4 +139,17 @@ class DebateRepositoryTest {
 		assertThat(res4).isFalse();
 	}
 
+	@Test
+	@DisplayName("특정 Document의 가장 최근 토론 조회")
+	void findLatestDebateByDocument() {
+		//given
+		
+		//when
+		Optional<Debate> latestDebateOptional = debateRepository.findLatestDebateByDocumentId(1L);
+
+		//then
+		assertThat(latestDebateOptional)
+			.isPresent();
+		assertThat(latestDebateOptional.get().getId()).isEqualTo(2L);
+	}
 }

--- a/src/test/java/goorm/eagle7/stelligence/domain/document/content/DocumentContentServiceReadUnitTest.java
+++ b/src/test/java/goorm/eagle7/stelligence/domain/document/content/DocumentContentServiceReadUnitTest.java
@@ -286,4 +286,29 @@ class DocumentContentServiceReadUnitTest {
 		assertThat(documentResponse.getDebateId()).isNull();
 	}
 
+	@Test
+	@DisplayName("문서 조회 - 상위 문서 존재")
+	void parentDocumentTest() {
+		//given
+		Document parentDocument = document(2L, member(2L, "world"), "parentTitle", 1L);
+		Document document = document(1L, member(1L, "hello"), "title11", 1L, parentDocument);
+
+		Section s1 = section(1L, 1L, document, Heading.H1, "title1", "content1", 1);
+
+		//when
+		when(documentContentRepository.findById(1L)).thenReturn(Optional.of(document));
+		when(sectionRepository.findByVersion(document, 1L)).thenReturn(List.of(s1));
+
+		//토론이 진행중이지 않음
+		when(debateRepository.findLatestDebateByDocumentId(1L)).thenReturn(Optional.empty());
+
+		//투표가 진행중이지 않음
+		when(contributeRepository.findLatestContributeByDocumentId(1L)).thenReturn(Optional.empty());
+
+		DocumentResponse documentResponse = documentContentService.getDocument(1L);
+
+		//then
+		assertThat(documentResponse.getParentDocumentId()).isEqualTo(2L);
+		assertThat(documentResponse.getParentDocumentTitle()).isEqualTo("parentTitle");
+	}
 }

--- a/src/test/java/goorm/eagle7/stelligence/domain/document/content/DocumentContentServiceReadUnitTest.java
+++ b/src/test/java/goorm/eagle7/stelligence/domain/document/content/DocumentContentServiceReadUnitTest.java
@@ -4,6 +4,7 @@ import static goorm.eagle7.stelligence.config.mockdata.TestFixtureGenerator.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -16,10 +17,13 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import goorm.eagle7.stelligence.api.exception.BaseException;
 import goorm.eagle7.stelligence.domain.contribute.ContributeRepository;
+import goorm.eagle7.stelligence.domain.contribute.model.Contribute;
 import goorm.eagle7.stelligence.domain.contribute.model.ContributeStatus;
+import goorm.eagle7.stelligence.domain.debate.model.Debate;
 import goorm.eagle7.stelligence.domain.debate.model.DebateStatus;
 import goorm.eagle7.stelligence.domain.debate.repository.DebateRepository;
 import goorm.eagle7.stelligence.domain.document.content.dto.DocumentResponse;
+import goorm.eagle7.stelligence.domain.document.content.dto.DocumentStatus;
 import goorm.eagle7.stelligence.domain.document.content.model.Document;
 import goorm.eagle7.stelligence.domain.section.SectionRepository;
 import goorm.eagle7.stelligence.domain.section.model.Heading;
@@ -99,10 +103,10 @@ class DocumentContentServiceReadUnitTest {
 			.thenReturn(List.of(s1, s2, s3));
 
 		//토론이 진행중이지 않은 상태
-		when(debateRepository.existsByContributeDocumentIdAndStatus(1L, DebateStatus.OPEN)).thenReturn(false);
+		when(debateRepository.findLatestDebateByDocumentId(1L)).thenReturn(Optional.empty());
 
 		//투표중이지 않은 상태
-		when(contributeRepository.existsByDocumentAndStatus(document, ContributeStatus.VOTING)).thenReturn(false);
+		when(contributeRepository.findLatestContributeByDocumentId(1L)).thenReturn(Optional.empty());
 
 		DocumentResponse documentResponse = documentContentService.getDocument(1L, 3L);
 
@@ -116,7 +120,7 @@ class DocumentContentServiceReadUnitTest {
 		assertThat(documentResponse.getSections().get(1).getSectionId()).isEqualTo(3L); //order 2
 		assertThat(documentResponse.getSections().get(2).getSectionId()).isEqualTo(2L); //order 3
 
-		assertThat(documentResponse.isEditable()).isTrue();
+		assertThat(documentResponse.getDocumentStatus()).isEqualTo(DocumentStatus.EDITABLE);
 
 		assertThat(documentResponse.getCurrentRevision()).isEqualTo(3L);
 		assertThat(documentResponse.getLatestRevision()).isEqualTo(4L);
@@ -166,6 +170,36 @@ class DocumentContentServiceReadUnitTest {
 	}
 
 	@Test
+	@DisplayName("문서 조회 - 수정 가능 - 수정요청 대기 상태 지남")
+	void editableTest() {
+
+		//given
+		Document document = document(1L, member(1L, "hello"), "title11", 1L);
+
+		Section s1 = section(1L, 1L, document, Heading.H1, "title1", "content1", 1);
+		Contribute contribute = contribute(2L, null, ContributeStatus.DEBATING, document);
+		Debate debate = debate(3L, contribute, DebateStatus.CLOSED,
+			LocalDateTime.now().minusMinutes(Debate.DEBATE_PENDING_DURATION_MINUTE).minusMinutes(1L), 1);
+
+		//when
+		when(documentContentRepository.findById(1L)).thenReturn(Optional.of(document));
+
+		when(sectionRepository.findByVersion(document, 1L)).thenReturn(List.of(s1));
+
+		//투표는 토론으로 이관된 상태
+		when(contributeRepository.findLatestContributeByDocumentId(1L)).thenReturn(Optional.of(contribute));
+		//토론은 종료되고, 수정 대기 상태에서 벗어남
+		when(debateRepository.findLatestDebateByDocumentId(1L)).thenReturn(Optional.of(debate));
+
+		DocumentResponse documentResponse = documentContentService.getDocument(1L);
+
+		//then
+		assertThat(documentResponse.getDocumentStatus()).isEqualTo(DocumentStatus.EDITABLE);
+		assertThat(documentResponse.getContributeId()).isNull();
+		assertThat(documentResponse.getDebateId()).isNull();
+	}
+
+	@Test
 	@DisplayName("문서 조회 - 수정 불가능 - 토론 진행중")
 	void editableTestDebatesOpen() {
 
@@ -173,22 +207,54 @@ class DocumentContentServiceReadUnitTest {
 		Document document = document(1L, member(1L, "hello"), "title11", 1L);
 
 		Section s1 = section(1L, 1L, document, Heading.H1, "title1", "content1", 1);
+		Contribute contribute = contribute(2L, null, ContributeStatus.DEBATING, document);
+		Debate debate = debate(3L, contribute, DebateStatus.OPEN, LocalDateTime.now().plusMinutes(30L), 1);
 
 		//when
 		when(documentContentRepository.findById(1L)).thenReturn(Optional.of(document));
 
 		when(sectionRepository.findByVersion(document, 1L)).thenReturn(List.of(s1));
 
-		//토론이 진행중인 상태
-		when(debateRepository.existsByContributeDocumentIdAndStatus(1L, DebateStatus.OPEN)).thenReturn(true);
-
-		//투표중이지 않은 상태
-		when(contributeRepository.existsByDocumentAndStatus(document, ContributeStatus.VOTING)).thenReturn(false);
+		//투표는 토론으로 이관된 상태
+		when(contributeRepository.findLatestContributeByDocumentId(1L)).thenReturn(Optional.of(contribute));
+		//토론이 진행중
+		when(debateRepository.findLatestDebateByDocumentId(1L)).thenReturn(Optional.of(debate));
 
 		DocumentResponse documentResponse = documentContentService.getDocument(1L);
 
 		//then
-		assertThat(documentResponse.isEditable()).isFalse();
+		assertThat(documentResponse.getDocumentStatus()).isEqualTo(DocumentStatus.DEBATING);
+		assertThat(documentResponse.getContributeId()).isNull();
+		assertThat(documentResponse.getDebateId()).isEqualTo(3L);
+	}
+
+	@Test
+	@DisplayName("문서 조회 - 수정 불가능 - 토론 종료 후 수정 대기중")
+	void editableTestDebatePending() {
+
+		//given
+		Document document = document(1L, member(1L, "hello"), "title11", 1L);
+
+		Section s1 = section(1L, 1L, document, Heading.H1, "title1", "content1", 1);
+		Contribute contribute = contribute(2L, null, ContributeStatus.DEBATING, document);
+		Debate debate = debate(3L, contribute, DebateStatus.CLOSED, LocalDateTime.now(), 1);
+
+		//when
+		when(documentContentRepository.findById(1L)).thenReturn(Optional.of(document));
+
+		when(sectionRepository.findByVersion(document, 1L)).thenReturn(List.of(s1));
+
+		//투표는 토론으로 이관된 상태
+		when(contributeRepository.findLatestContributeByDocumentId(1L)).thenReturn(Optional.of(contribute));
+		//토론 종료 후 수정 대기중
+		when(debateRepository.findLatestDebateByDocumentId(1L)).thenReturn(Optional.of(debate));
+
+		DocumentResponse documentResponse = documentContentService.getDocument(1L);
+
+		//then
+		assertThat(documentResponse.getDocumentStatus()).isEqualTo(DocumentStatus.PENDING);
+		assertThat(documentResponse.getContributeId()).isNull();
+		assertThat(documentResponse.getDebateId()).isEqualTo(3L);
 	}
 
 	@Test
@@ -199,6 +265,7 @@ class DocumentContentServiceReadUnitTest {
 		Document document = document(1L, member(1L, "hello"), "title11", 1L);
 
 		Section s1 = section(1L, 1L, document, Heading.H1, "title1", "content1", 1);
+		Contribute contribute = contribute(2L, null, ContributeStatus.VOTING, document);
 
 		//when
 		when(documentContentRepository.findById(1L)).thenReturn(Optional.of(document));
@@ -206,15 +273,17 @@ class DocumentContentServiceReadUnitTest {
 		when(sectionRepository.findByVersion(document, 1L)).thenReturn(List.of(s1));
 
 		//토론이 진행중이지 않음
-		when(debateRepository.existsByContributeDocumentIdAndStatus(1L, DebateStatus.OPEN)).thenReturn(false);
+		when(debateRepository.findLatestDebateByDocumentId(1L)).thenReturn(Optional.empty());
 
 		//투표중인 상태
-		when(contributeRepository.existsByDocumentAndStatus(document, ContributeStatus.VOTING)).thenReturn(true);
+		when(contributeRepository.findLatestContributeByDocumentId(1L)).thenReturn(Optional.of(contribute));
 
 		DocumentResponse documentResponse = documentContentService.getDocument(1L);
 
 		//then
-		assertThat(documentResponse.isEditable()).isFalse();
+		assertThat(documentResponse.getDocumentStatus()).isEqualTo(DocumentStatus.VOTING);
+		assertThat(documentResponse.getContributeId()).isEqualTo(2L);
+		assertThat(documentResponse.getDebateId()).isNull();
 	}
 
 }

--- a/src/test/resources/dummy.sql
+++ b/src/test/resources/dummy.sql
@@ -95,8 +95,8 @@ values (1, 1, 2, 1, null, 'H2', 'document1_title2_update', 'document1_content2_u
        (7, 5, 6, 1, null, 'H1', 'document2_title3_update', 'document2_content3_update', 'UPDATE', NOW(), NOW());
 
 insert into debate (debate_id, contribute_id, status, end_at, comment_sequence, created_at)
-values (1, 1, 'OPEN', TIMESTAMPADD(HOUR, 1, NOW()), 1, NOW()),
-       (2, 2, 'OPEN', TIMESTAMPADD(MINUTE, -1, NOW()), 1, NOW()),
+values (1, 1, 'OPEN', TIMESTAMPADD(HOUR, 1, NOW()), 1, TIMESTAMPADD(HOUR, -3, NOW())),
+       (2, 2, 'OPEN', TIMESTAMPADD(MINUTE, -1, NOW()), 1, TIMESTAMPADD(HOUR, -1, NOW())),
        (3, 3, 'OPEN', TIMESTAMPADD(MINUTE, -1, NOW()), 1, NOW()),
        (4, 4, 'CLOSED', NOW(), 1, NOW()),
        (5, 5, 'CLOSED', NOW(), 1, NOW()),


### PR DESCRIPTION
## 변경 내용 

- 문서 상세 조회 시 다음과 같은 필드를 함께 확인할 수 있습니다.
  - 문서 상태: 수정가능 / 투표중 / 토론중 / 토론후수정대기중
  - 상위 문서 조회

## 특이 사항

- X

## 체크리스트

- [x] PR 날리기 전에 main branch pull 받으셨나요?
- [x] application.properties 등 노출되지 않아야 하는 파일이 올라가지는 않았나요?
- [x] 다른 담당자 파일을 수정한 부분에 대해서 이야기 하셨나요?
- [x] 주석 "상세히" 다셨나요?
- [x] 제출하기 전에 테스트코드 돌려 보셨나요?

closes #
