### PR TITLE
233 토론 댓글 글자수 제한 1000자로 조정

### DIFF
--- a/src/main/java/goorm/eagle7/stelligence/domain/debate/DebateService.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/debate/DebateService.java
@@ -70,6 +70,10 @@ public class DebateService {
 	@Transactional
 	public List<CommentResponse> addComment(CommentRequest commentRequest, Long debateId, Long loginMemberId) {
 
+		if (commentRequest.getContent().length() > 1000) {
+			throw new BaseException("토론 댓글의 최대 길이는 1000 자 입니다.");
+		}
+
 		Debate findDebate = debateRepository.findDebateByIdForUpdate(debateId)
 			.orElseThrow(() -> new BaseException("존재하지 않는 토론에 대한 댓글 작성요청입니다. Debate ID: " + debateId));
 

--- a/src/main/java/goorm/eagle7/stelligence/domain/debate/DebateService.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/debate/DebateService.java
@@ -71,7 +71,7 @@ public class DebateService {
 	public List<CommentResponse> addComment(CommentRequest commentRequest, Long debateId, Long loginMemberId) {
 
 		if (commentRequest.getContent().length() > Comment.MAX_COMMENT_LENGTH) {
-			throw new BaseException("토론 댓글의 최대 길이는 1000 자 입니다.");
+			throw new BaseException("토론 댓글의 최대 길이는 " + Comment.MAX_COMMENT_LENGTH + " 자 입니다.");
 		}
 
 		Debate findDebate = debateRepository.findDebateByIdForUpdate(debateId)

--- a/src/main/java/goorm/eagle7/stelligence/domain/debate/DebateService.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/debate/DebateService.java
@@ -70,7 +70,7 @@ public class DebateService {
 	@Transactional
 	public List<CommentResponse> addComment(CommentRequest commentRequest, Long debateId, Long loginMemberId) {
 
-		if (commentRequest.getContent().length() > 1000) {
+		if (commentRequest.getContent().length() > Comment.MAX_COMMENT_LENGTH) {
 			throw new BaseException("토론 댓글의 최대 길이는 1000 자 입니다.");
 		}
 

--- a/src/main/java/goorm/eagle7/stelligence/domain/debate/DebateService.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/debate/DebateService.java
@@ -6,6 +6,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 import goorm.eagle7.stelligence.api.exception.BaseException;
 import goorm.eagle7.stelligence.domain.debate.dto.CommentRequest;
@@ -70,6 +71,9 @@ public class DebateService {
 	@Transactional
 	public List<CommentResponse> addComment(CommentRequest commentRequest, Long debateId, Long loginMemberId) {
 
+		if (!StringUtils.hasText(commentRequest.getContent())) {
+			throw new BaseException("댓글에 내용이 존재하지 않습니다.");
+		}
 		if (commentRequest.getContent().length() > Comment.MAX_COMMENT_LENGTH) {
 			throw new BaseException("토론 댓글의 최대 길이는 " + Comment.MAX_COMMENT_LENGTH + " 자 입니다.");
 		}

--- a/src/main/java/goorm/eagle7/stelligence/domain/debate/DebateService.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/debate/DebateService.java
@@ -26,7 +26,7 @@ import lombok.extern.slf4j.Slf4j;
 @Service
 @RequiredArgsConstructor
 @Slf4j
-@Transactional
+@Transactional(readOnly = true)
 public class DebateService {
 
 	private final DebateRepository debateRepository;
@@ -39,7 +39,6 @@ public class DebateService {
 	 * @param debateId: 조회할 토론의 ID
 	 * @return DebateResponse: 조회된 토론 응답 DTO
 	 */
-	@Transactional(readOnly = true)
 	public DebateResponse getDebateDetailById(Long debateId) {
 		Debate findDebate = debateRepository.findByIdWithContribute(debateId)
 			.orElseThrow(() -> new BaseException("존재하지 않는 토론에 대한 조회 요청입니다. Debate ID: " + debateId));
@@ -54,7 +53,6 @@ public class DebateService {
 	 * @param pageable: 조회하려는 토론의 페이지 정보
 	 * @return DebatePageResponse: 조회된 토론 페이지 응답 DTO
 	 */
-	@Transactional(readOnly = true)
 	public DebatePageResponse getDebatePage(DebateStatus status, DebateOrderCondition orderCondition, Pageable pageable) {
 
 		Page<Debate> debatePage = debateRepository.findPageByStatusAndOrderCondition(status, orderCondition, pageable);
@@ -69,6 +67,7 @@ public class DebateService {
 	 * @param loginMemberId: 현재 로그인한 회원의 ID
 	 * @return List&lt;CommentResponse&gt;: 댓글이 달린 토론의 전체 댓글 리스트
 	 */
+	@Transactional
 	public List<CommentResponse> addComment(CommentRequest commentRequest, Long debateId, Long loginMemberId) {
 
 		Debate findDebate = debateRepository.findDebateByIdForUpdate(debateId)
@@ -93,6 +92,7 @@ public class DebateService {
 	 * @param commentId: 삭제할 댓글의 ID
 	 * @param loginMemberId: 로그인한 회원의 ID
 	 */
+	@Transactional
 	public void deleteComment(Long commentId, Long loginMemberId) {
 
 		Comment targetComment = commentRepository.findById(commentId)
@@ -112,6 +112,7 @@ public class DebateService {
 	 * @param loginMemberId: 로그인한 회원의 ID
 	 * @return CommentResponse: 수정된 댓글
 	 */
+	@Transactional
 	public CommentResponse updateComment(Long commentId, CommentRequest commentRequest, Long loginMemberId) {
 
 		Comment updateComment = commentRepository.findById(commentId)
@@ -130,7 +131,6 @@ public class DebateService {
 	 * @param debateId: 댓글을 조회할 토론의 ID
 	 * @return List&lt;CommentResponse&gt;: 조회된 댓글의 리스트
 	 */
-	@Transactional(readOnly = true)
 	public List<CommentResponse> getComments(Long debateId) {
 
 		List<Comment> comments = commentRepository.findAllByDebateId(debateId);

--- a/src/main/java/goorm/eagle7/stelligence/domain/debate/model/Comment.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/debate/model/Comment.java
@@ -32,6 +32,7 @@ public class Comment extends BaseTimeEntity {
 	@JoinColumn(name = "commenter_id")
 	private Member commenter;
 
+	@Column(length = 1000)
 	private String content;
 
 	@Column(name = "sequences")

--- a/src/main/java/goorm/eagle7/stelligence/domain/debate/model/Comment.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/debate/model/Comment.java
@@ -19,6 +19,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Comment extends BaseTimeEntity {
 
+	public static final int MAX_COMMENT_LENGTH = 1000;
+
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "comment_id")
@@ -32,7 +34,7 @@ public class Comment extends BaseTimeEntity {
 	@JoinColumn(name = "commenter_id")
 	private Member commenter;
 
-	@Column(length = 1000)
+	@Column(length = MAX_COMMENT_LENGTH)
 	private String content;
 
 	@Column(name = "sequences")

--- a/src/test/java/goorm/eagle7/stelligence/domain/debate/DebateServiceCommentTest.java
+++ b/src/test/java/goorm/eagle7/stelligence/domain/debate/DebateServiceCommentTest.java
@@ -300,6 +300,52 @@ class DebateServiceCommentTest {
 
 	}
 
+	@Test
+	@DisplayName("빈 댓글 테스트")
+	void emptyComment() {
+		//given
+		final String content = " ";
+
+		CommentRequest commentRequest = CommentRequest.of(content);
+
+		Long debateId = 1L;
+		Long commenterId = 1L;
+		Debate debate = TestFixtureGenerator.debate(debateId, null, DebateStatus.OPEN,
+			LocalDateTime.now(), 1, LocalDateTime.now());
+		Member commenter = TestFixtureGenerator.member(commenterId, "commenter");
+
+		//when
+
+		//then
+		assertThatThrownBy(() -> debateService.addComment(commentRequest, debateId, commenterId))
+			.isInstanceOf(BaseException.class)
+			.hasMessage("댓글에 내용이 존재하지 않습니다.");
+
+	}
+
+	@Test
+	@DisplayName("null 댓글 테스트")
+	void nullComment() {
+		//given
+		final String content = null;
+
+		CommentRequest commentRequest = CommentRequest.of(content);
+
+		Long debateId = 1L;
+		Long commenterId = 1L;
+		Debate debate = TestFixtureGenerator.debate(debateId, null, DebateStatus.OPEN,
+			LocalDateTime.now(), 1, LocalDateTime.now());
+		Member commenter = TestFixtureGenerator.member(commenterId, "commenter");
+
+		//when
+
+		//then
+		assertThatThrownBy(() -> debateService.addComment(commentRequest, debateId, commenterId))
+			.isInstanceOf(BaseException.class)
+			.hasMessage("댓글에 내용이 존재하지 않습니다.");
+
+	}
+
 	private static String getKorStringWithLength(int length) {
 		String content = "안녕하세요 이영민입니다 반갑습니다~\n";
 		assertThat(content).hasSize(20);

--- a/src/test/java/goorm/eagle7/stelligence/domain/debate/DebateServiceCommentTest.java
+++ b/src/test/java/goorm/eagle7/stelligence/domain/debate/DebateServiceCommentTest.java
@@ -238,7 +238,7 @@ class DebateServiceCommentTest {
 	}
 
 	@Test
-	@DisplayName("토론 리스트 조회")
+	@DisplayName("토론 댓글 리스트 조회")
 	void getComments() {
 		// given
 		Long debateId = 1L;
@@ -269,13 +269,17 @@ class DebateServiceCommentTest {
 """;
 		System.out.println("content.length() = " + content.length());
 		CommentRequest commentRequest = CommentRequest.of(content);
-		Debate debate = TestFixtureGenerator.debate(1L, null, DebateStatus.OPEN, LocalDateTime.now(), 1);
-		Member commenter = TestFixtureGenerator.member(2L, "commenter");
+
+		Long debateId = 1L;
+		Long commenterId = 1L;
+		Debate debate = TestFixtureGenerator.debate(debateId, null, DebateStatus.OPEN,
+			LocalDateTime.now(), 1, LocalDateTime.now());
+		Member commenter = TestFixtureGenerator.member(commenterId, "commenter");
 
 		//when
 
 		//then
-		assertThatThrownBy(() -> debateService.addComment(commentRequest, debate.getId(), commenter.getId()))
+		assertThatThrownBy(() -> debateService.addComment(commentRequest, debateId, commenterId))
 			.isInstanceOf(BaseException.class)
 			.hasMessage("토론 댓글의 최대 길이는 " + Comment.MAX_COMMENT_LENGTH + " 자 입니다.");
 

--- a/src/test/java/goorm/eagle7/stelligence/domain/debate/DebateServiceCommentTest.java
+++ b/src/test/java/goorm/eagle7/stelligence/domain/debate/DebateServiceCommentTest.java
@@ -250,4 +250,67 @@ class DebateServiceCommentTest {
 		// then
 		verify(commentRepository, times(1)).findAllByDebateId(debateId);
 	}
+
+	@Test
+	@DisplayName("댓글 최대 길이 초과 테스트")
+	void commentMaxLengthExceed() {
+		//given
+		String content = """
+안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~
+안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~
+안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~
+안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~
+안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~
+안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~
+안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~
+안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~
+안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~
+안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~
+""";
+		System.out.println("content.length() = " + content.length());
+		CommentRequest commentRequest = CommentRequest.of(content);
+		Debate debate = TestFixtureGenerator.debate(1L, null, DebateStatus.OPEN, LocalDateTime.now(), 1);
+		Member commenter = TestFixtureGenerator.member(2L, "commenter");
+
+		//when
+
+		//then
+		assertThatThrownBy(() -> debateService.addComment(commentRequest, debate.getId(), commenter.getId()))
+			.isInstanceOf(BaseException.class)
+			.hasMessage("토론 댓글의 최대 길이는 " + Comment.MAX_COMMENT_LENGTH + " 자 입니다.");
+
+	}
+
+	@Test
+	@DisplayName("댓글 최대 길이 성공 테스트")
+	void commentMaxLengthPass() {
+		//given
+		String content = """
+안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~
+안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~
+안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~
+안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~
+안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~
+안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~
+안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~
+안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~
+안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~
+안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입
+""";
+		System.out.println("content.length() = " + content.length());
+		CommentRequest commentRequest = CommentRequest.of(content);
+		Debate debate = TestFixtureGenerator.debate(1L, null, DebateStatus.OPEN, LocalDateTime.now(),
+			1, LocalDateTime.now());
+		Member commenter = TestFixtureGenerator.member(2L, "commenter");
+
+		when(memberRepository.findById(commenter.getId())).thenReturn(Optional.of(commenter));
+		when(debateRepository.findDebateByIdForUpdate(debate.getId())).thenReturn(Optional.of(debate));
+
+		//when
+		debateService.addComment(commentRequest, debate.getId(), commenter.getId());
+
+		//then
+		verify(commentRepository, times(1)).save(any(Comment.class));
+
+	}
 }

--- a/src/test/java/goorm/eagle7/stelligence/domain/debate/DebateServiceCommentTest.java
+++ b/src/test/java/goorm/eagle7/stelligence/domain/debate/DebateServiceCommentTest.java
@@ -255,19 +255,10 @@ class DebateServiceCommentTest {
 	@DisplayName("댓글 최대 길이 초과 테스트")
 	void commentMaxLengthExceed() {
 		//given
-		String content = """
-안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~
-안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~
-안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~
-안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~
-안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~
-안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~
-안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~
-안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~
-안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~
-안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~
-""";
-		System.out.println("content.length() = " + content.length());
+		final int length = Comment.MAX_COMMENT_LENGTH + 1;
+		final String content = getKorStringWithLength(length);
+		assertThat(content.length()).isGreaterThan(Comment.MAX_COMMENT_LENGTH);
+
 		CommentRequest commentRequest = CommentRequest.of(content);
 
 		Long debateId = 1L;
@@ -289,19 +280,10 @@ class DebateServiceCommentTest {
 	@DisplayName("댓글 최대 길이 성공 테스트")
 	void commentMaxLengthPass() {
 		//given
-		String content = """
-안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~
-안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~
-안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~
-안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~
-안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~
-안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~
-안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~
-안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~
-안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~
-안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입니다 반갑습니다~~안녕하세요 이영민입
-""";
-		System.out.println("content.length() = " + content.length());
+		final int length = Comment.MAX_COMMENT_LENGTH;
+		final String content = getKorStringWithLength(length);
+		assertThat(content.length()).isLessThanOrEqualTo(Comment.MAX_COMMENT_LENGTH);
+
 		CommentRequest commentRequest = CommentRequest.of(content);
 		Debate debate = TestFixtureGenerator.debate(1L, null, DebateStatus.OPEN, LocalDateTime.now(),
 			1, LocalDateTime.now());
@@ -316,5 +298,16 @@ class DebateServiceCommentTest {
 		//then
 		verify(commentRepository, times(1)).save(any(Comment.class));
 
+	}
+
+	private static String getKorStringWithLength(int length) {
+		String content = "안녕하세요 이영민입니다 반갑습니다~\n";
+		assertThat(content).hasSize(20);
+
+		StringBuilder stringBuilder = new StringBuilder();
+		while (stringBuilder.length() < length) {
+			stringBuilder.append(content);
+		}
+		return stringBuilder.substring(0, length);
 	}
 }


### PR DESCRIPTION
## 변경 내용 

- 비즈니스 요구사항에 따라 토론 댓글의 글자수를 1000자로 제한하는 로직을 추가하였습니다.

## 특이 사항

- 아래 링크를 참고하여, 최대 길이가 (상대적으로) 크지 않으므로 TEXT가 아닌 VARCHAR(1000)으로 결정하였습니다.
  - https://medium.com/daangn/varchar-vs-text-230a718a22a1

## 체크리스트

- [x] PR 날리기 전에 main branch pull 받으셨나요?
- [x] application.properties 등 노출되지 않아야 하는 파일이 올라가지는 않았나요?
- [x] 다른 담당자 파일을 수정한 부분에 대해서 이야기 하셨나요?
- [x] 주석 "상세히" 다셨나요?
- [x] 제출하기 전에 테스트코드 돌려 보셨나요?

closes #
