### PR TITLE
[#236] fix: badgeResponse imgUrl, description 순서 잘못돼 정정

### DIFF
--- a/src/main/java/goorm/eagle7/stelligence/domain/member/dto/MemberBadgesResponse.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/member/dto/MemberBadgesResponse.java
@@ -23,8 +23,9 @@ public class MemberBadgesResponse {
 			badge.name(),
 			badge.getTitle(),
 			badge.getEventCategory().getLabel(),
-			badge.getImgFilename(),
-			badge.getDescription()
+			badge.getDescription(),
+			badge.getImgFilename()
+
 		);
 
 	}


### PR DESCRIPTION
## 변경 내용 
- badgeResponse에서 imgUrl, description 순서 뒤바뀌어서 정정

## 특이 사항
- 

## 체크리스트

- [X] PR 날리기 전에 main branch pull 받으셨나요?
- [X] application.properties 등 노출되지 않아야 하는 파일이 올라가지는 않았나요?
- [X] 다른 담당자 파일을 수정한 부분에 대해서 이야기 하셨나요?
- [X] 주석 "상세히" 다셨나요?
- [X] 제출하기 전에 테스트코드 돌려 보셨나요?

closes #236
