### PR TITLE
239 토론 상세조회 api contribute 내용 보완

### DIFF
--- a/src/main/java/goorm/eagle7/stelligence/domain/debate/dto/DebateResponse.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/debate/dto/DebateResponse.java
@@ -1,12 +1,10 @@
 package goorm.eagle7.stelligence.domain.debate.dto;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
-import goorm.eagle7.stelligence.domain.amendment.dto.AmendmentResponse;
+import goorm.eagle7.stelligence.domain.contribute.dto.ContributeResponse;
 import goorm.eagle7.stelligence.domain.debate.model.Debate;
 import goorm.eagle7.stelligence.domain.debate.model.DebateStatus;
-import goorm.eagle7.stelligence.domain.member.dto.MemberSimpleResponse;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -21,20 +19,7 @@ public class DebateResponse {
 	private LocalDateTime endAt;
 	private DebateStatus status;
 
-	// 문서 정보
-	private Long documentId;
-	private String documentTitle;
-
-	// 수정요청자 정보
-	private MemberSimpleResponse contributor;
-
-	// 수정요청 정보
-	private Long contributeId;
-	private String contributeTitle;
-	private String contributeDescription;
-
-	// 수정안 정보
-	private List<AmendmentResponse> amendments;
+	private ContributeResponse contribute;
 
 	public static DebateResponse of(Debate debate) {
 		return new DebateResponse(debate);
@@ -46,15 +31,6 @@ public class DebateResponse {
 		this.endAt = debate.getEndAt();
 		this.status = debate.getStatus();
 
-		this.documentId = debate.getContribute().getDocument().getId();
-		this.documentTitle = debate.getContribute().getDocument().getTitle();
-
-		this.contributor = MemberSimpleResponse.from(debate.getContribute().getMember());
-
-		this.contributeId = debate.getContribute().getId();
-		this.contributeTitle = debate.getContribute().getTitle();
-		this.contributeDescription = debate.getContribute().getDescription();
-
-		this.amendments = debate.getContribute().getAmendments().stream().map(AmendmentResponse::of).toList();
+		this.contribute = ContributeResponse.of(debate.getContribute());
 	}
 }

--- a/src/test/java/goorm/eagle7/stelligence/config/mockdata/TestFixtureGenerator.java
+++ b/src/test/java/goorm/eagle7/stelligence/config/mockdata/TestFixtureGenerator.java
@@ -275,6 +275,12 @@ public class TestFixtureGenerator {
 			newParentDocumentField.set(contribute, afterParentDocument);
 			relatedDebateField.set(contribute, relatedDebate);
 
+			// createdAt 설정
+			Class<?> baseTimeEntityClazz = contributeClazz.getSuperclass();
+			Field createdAtField = baseTimeEntityClazz.getDeclaredField("createdAt");
+			createdAtField.setAccessible(true);
+			createdAtField.set(contribute, LocalDateTime.now());
+
 			return (Contribute)contribute;
 
 		} catch (Exception e) {


### PR DESCRIPTION
## 변경 내용 

- DebateResponse에 포함된 수정요청 정보를 ContributeResponse로 대체하였습니다.

## 특이 사항

- DebateResponse의 endAt과 ContributeResponse의 endAt이 모호하긴 하지만, results.endAt / results.contribute.endAt 으로 구분할 수 있어 그냥 두었습니다. 혹시나 문제가 될 것 같다면 피드백 주시면 debateEndAt 등으로 수정을 고려하겠습니다!
- ContributeResponse로 대체하면서, 테스트 코드에서 Contribute의 createdAt이 필요해졌습니다.
  - 그래서 TestFixtureGenerator의 Contribute에 createdAt 필드를 추가했습니다.
  - 파급을 최소화하기 위해 createdAt은 파라미터로 받지 않고 LocalDateTime.now()로 설정하였습니다.
  - @eenzzi, @sbslc2000 확인 부탁드립니다!!
- TestFixtureGenerator 의 변경 때문에 맘대로 머지하지 못했습니다! 확인 후 머지 부탁드립니다 :)

## 체크리스트

- [x] PR 날리기 전에 main branch pull 받으셨나요?
- [x] application.properties 등 노출되지 않아야 하는 파일이 올라가지는 않았나요?
- [x] 다른 담당자 파일을 수정한 부분에 대해서 이야기 하셨나요?
- [x] 주석 "상세히" 다셨나요?
- [x] 제출하기 전에 테스트코드 돌려 보셨나요?

closes #
