### PR TITLE
[#250] fix: preflight 해결 위해 POST uri에 OPTIONS 추가

### DIFF
--- a/src/main/java/goorm/eagle7/stelligence/common/auth/filter/AuthFilter.java
+++ b/src/main/java/goorm/eagle7/stelligence/common/auth/filter/AuthFilter.java
@@ -97,7 +97,9 @@ public class AuthFilter extends OncePerRequestFilter {
 		} catch (BaseException e) {
 
 			// 로그아웃 시에는 토큰 검증이 필요 없음, 로그아웃 요청이 아니면 다시 같은 ex 발생
-			if ((httpMethod.equals("POST") && uri.equals("/api/logout"))) {
+			if ((httpMethod.equals("POST") && uri.equals("/api/logout")
+				|| (httpMethod.equals("OPTIONS") && uri.equals(
+				"/api/logout")))) {
 				filterChain.doFilter(request, response);
 			} else {
 

--- a/src/main/java/goorm/eagle7/stelligence/common/auth/filter/PermittedPathStore.java
+++ b/src/main/java/goorm/eagle7/stelligence/common/auth/filter/PermittedPathStore.java
@@ -38,9 +38,11 @@ class PermittedPathStore {
 
 			// error
 			RequestResource.of(HttpMethod.POST.name(), "/error/**"),
+			RequestResource.of(HttpMethod.OPTIONS.name(), "/error/**"),
 
 			// login - dev
 			RequestResource.of(HttpMethod.POST.name(), "/api/login"),
+			RequestResource.of(HttpMethod.OPTIONS.name(), "/api/login"),
 			RequestResource.of(HttpMethod.GET.name(), "/api/oauth2/**")
 		);
 


### PR DESCRIPTION
## 변경 내용 
- /api/login 에서 CORS error 지속 발생해 디버깅 중 postman에서 options로 보내면 authfilter에서 uri pass가 아닌 것 확인해 추가
  - 기존 테스트 시 headers - origin, www.stelligence.site는 통과했음.
- Access to XMLHttpRequest at 'https://api.stelligence.site/api/login' from origin 'http://www.stelligence.site' has been blocked by CORS policy: Response to preflight request doesn't pass access control check: No 'Access-Control-Allow-Origin' header is present on the requested resource.

## 특이 사항
- cors 해결해야 프론트 다른 테스트 가능해 긴급 병합 시도.

## 체크리스트
- [X] PR 날리기 전에 main branch pull 받으셨나요?
- [X] application.properties 등 노출되지 않아야 하는 파일이 올라가지는 않았나요?
- [X] 다른 담당자 파일을 수정한 부분에 대해서 이야기 하셨나요?
- [X] 주석 "상세히" 다셨나요?
- [X] 제출하기 전에 테스트코드 돌려 보셨나요?

closes #
