### PR TITLE
[#252] fix: preflight 해결 위해 OPTIONS면 바로 200 반환하는 코드 추가 - 임시방편

### DIFF
--- a/src/main/java/goorm/eagle7/stelligence/common/auth/filter/AuthFilter.java
+++ b/src/main/java/goorm/eagle7/stelligence/common/auth/filter/AuthFilter.java
@@ -54,6 +54,10 @@ public class AuthFilter extends OncePerRequestFilter {
 
 		String httpMethod = request.getMethod();
 		String uri = request.getRequestURI();
+		if(httpMethod.equals("OPTIONS")) {
+			response.setStatus(HttpServletResponse.SC_OK);
+			return;
+		}
 
 		try {
 			// 토큰 검증이 필요한 uri라면 토큰 검증


### PR DESCRIPTION
## 변경 내용 
- authFilter에서 Options 메서드면 무조건 200 OK 반환하는 코드 추가
- 임시 방편으로 우선, 200 반환하면 되는지 확인 위함.

## 특이 사항
- 

## 체크리스트
- [X] PR 날리기 전에 main branch pull 받으셨나요?
- [X] application.properties 등 노출되지 않아야 하는 파일이 올라가지는 않았나요?
- [X] 다른 담당자 파일을 수정한 부분에 대해서 이야기 하셨나요?
- [X] 주석 "상세히" 다셨나요?
- [X] 제출하기 전에 테스트코드 돌려 보셨나요?

closes #252 
