### PR TITLE
261 헤딩 태그 1~3으로 제한

### DIFF
--- a/src/main/java/goorm/eagle7/stelligence/domain/document/content/parser/TagDocumentParser.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/document/content/parser/TagDocumentParser.java
@@ -8,6 +8,7 @@ import java.util.regex.Pattern;
 import org.owasp.html.PolicyFactory;
 import org.springframework.stereotype.Component;
 
+import goorm.eagle7.stelligence.api.exception.BaseException;
 import goorm.eagle7.stelligence.domain.document.content.dto.SectionRequest;
 import goorm.eagle7.stelligence.domain.section.model.Heading;
 import lombok.RequiredArgsConstructor;
@@ -41,7 +42,9 @@ public class TagDocumentParser implements DocumentParser {
 		Matcher matcher = HEADING_TAG_PATTERN.matcher(sanitizedContent);
 
 		while (matcher.find()) {
-			Heading heading = Heading.valueOf("H" + matcher.group(2)); // h 태그의 숫자를 Heading enum의 이름으로 사용합니다.
+			String level = getValidLevel(matcher.group(2));
+
+			Heading heading = Heading.valueOf("H" + level); // h 태그의 숫자를 Heading enum의 이름으로 사용합니다.
 			String title = matcher.group(3); // 타이틀은 h 태그 사이의 내용입니다.
 			String content = matcher.group(4).trim(); // 콘텐츠는 다음 h 태그 전까지입니다.
 
@@ -50,4 +53,19 @@ public class TagDocumentParser implements DocumentParser {
 
 		return sectionRequests;
 	}
+
+	/**
+	 * 들어온 Heading의 수준을 정제하여 반환합니다.
+	 * 4 5 6 은 사용되면 안되므로, 3으로 변경하여 반환합니다.
+	 * @param level Heading의 수준
+	 * @return 유효한 Heading의 수준
+	 */
+	private String getValidLevel(String level) {
+		return switch (level) {
+			case "1", "2", "3" -> level;
+			case "4", "5", "6" -> "3";
+			default -> throw new BaseException("잘못된 Heading 수준입니다. " + level);
+		};
+	}
+
 }

--- a/src/main/java/goorm/eagle7/stelligence/domain/section/model/Heading.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/section/model/Heading.java
@@ -9,10 +9,7 @@ import lombok.Getter;
 public enum Heading {
 	H1("h1"),
 	H2("h2"),
-	H3("h3"),
-	H4("h4"),
-	H5("h5"),
-	H6("h6");
+	H3("h3");
 
 	private final String tag;
 

--- a/src/test/java/goorm/eagle7/stelligence/domain/contribute/scheduler/template/CreateAmendmentMergeTemplateTest.java
+++ b/src/test/java/goorm/eagle7/stelligence/domain/contribute/scheduler/template/CreateAmendmentMergeTemplateTest.java
@@ -70,7 +70,7 @@ class CreateAmendmentMergeTemplateTest {
 		Section s1 = section(2L, 1L, document, Heading.H1, "title", "content", 1);
 		Section s2 = section(3L, 1L, document, Heading.H2, "title", "content", 2);
 		Section s3 = section(4L, 1L, document, Heading.H3, "title", "content", 3);
-		Section s4 = section(5L, 1L, document, Heading.H4, "title", "content", 4);
+		Section s4 = section(5L, 1L, document, Heading.H3, "title", "content", 4);
 
 		//when
 		when(sectionRepository.findByVersionWhereOrderGreaterEqualThan(document, document.getLatestRevision(), 3))

--- a/src/test/java/goorm/eagle7/stelligence/domain/document/content/parser/TagDocumentParserTest.java
+++ b/src/test/java/goorm/eagle7/stelligence/domain/document/content/parser/TagDocumentParserTest.java
@@ -1,6 +1,7 @@
 package goorm.eagle7.stelligence.domain.document.content.parser;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 import java.util.List;
 
@@ -9,7 +10,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.owasp.html.PolicyFactory;
 
@@ -39,7 +39,7 @@ class TagDocumentParserTest {
 				+ "<p>content3</p>";
 
 		//when
-		Mockito.when(policyFactory.sanitize(rawContent)).thenReturn(rawContent);
+		when(policyFactory.sanitize(rawContent)).thenReturn(rawContent);
 		List<SectionRequest> result = tagDocumentParser.parse(rawContent);
 
 		//then
@@ -72,7 +72,7 @@ class TagDocumentParserTest {
 				+ "<p>content3</p>";
 
 		//when
-		Mockito.when(policyFactory.sanitize(rawContent)).thenReturn(rawContent);
+		when(policyFactory.sanitize(rawContent)).thenReturn(rawContent);
 		List<SectionRequest> result = tagDocumentParser.parse(rawContent);
 
 		//then
@@ -100,7 +100,7 @@ class TagDocumentParserTest {
 				+ "<p>content3</p>";
 
 		//when
-		Mockito.when(policyFactory.sanitize(rawContent)).thenReturn(rawContent);
+		when(policyFactory.sanitize(rawContent)).thenReturn(rawContent);
 		List<SectionRequest> result = tagDocumentParser.parse(rawContent);
 
 		//then
@@ -117,5 +117,28 @@ class TagDocumentParserTest {
 		assertThat(result.get(2).getHeading()).isEqualTo(Heading.H3);
 		assertThat(result.get(2).getTitle()).isEqualTo("title3");
 		assertThat(result.get(2).getContent()).isEqualTo("<p>content3</p>");
+	}
+
+	@Test
+	@DisplayName("h4 이상의 heading tag가 있는 경우")
+	void validHeadingTag() {
+		String rawContent =
+			"<h1>h1</h1>"
+				+ "<h2>h2</h2>"
+				+ "<h3>h3</h3>"
+				+ "<h4>h4</h4>"
+				+ "<h5>h5</h5>"
+				+ "<h6>h6</h6>";
+
+		//when
+		when(policyFactory.sanitize(rawContent)).thenReturn(rawContent);
+		List<SectionRequest> result = tagDocumentParser.parse(rawContent);
+
+		//then
+		assertThat(result).hasSize(6);
+		assertThat(result.get(3).getHeading()).isEqualTo(Heading.H3);
+		assertThat(result.get(4).getHeading()).isEqualTo(Heading.H3);
+		assertThat(result.get(5).getHeading()).isEqualTo(Heading.H3);
+
 	}
 }


### PR DESCRIPTION
## 변경 내용 

- 이제는 헤딩 태그를 3까지로 제한해서 관리합니다.
- h4에서 h6이 오는 경우는 오류로 처리하지 않고, h3으로 변경하여 저장합니다.

## 특이 사항

- 

## 체크리스트

- [x] PR 날리기 전에 main branch pull 받으셨나요?
- [x] application.properties 등 노출되지 않아야 하는 파일이 올라가지는 않았나요?
- [x] 다른 담당자 파일을 수정한 부분에 대해서 이야기 하셨나요?
- [x] 주석 "상세히" 다셨나요?
- [x] 제출하기 전에 테스트코드 돌려 보셨나요?

closes #261 
