### PR TITLE
267 Notification과 Member의 연관관계 및 FK 제거

### DIFF
--- a/src/main/java/goorm/eagle7/stelligence/domain/document/DocumentRequestValidator.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/document/DocumentRequestValidator.java
@@ -2,7 +2,6 @@ package goorm.eagle7.stelligence.domain.document;
 
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.util.StringUtils;
 
 import goorm.eagle7.stelligence.api.exception.BaseException;
 import goorm.eagle7.stelligence.domain.contribute.ContributeRepository;
@@ -35,16 +34,6 @@ public class DocumentRequestValidator {
 	 */
 	@Transactional(readOnly = true)
 	public void validate(DocumentCreateRequest request) {
-
-		//문서의 제목이 null이나 빈값이 아닌가?
-		if (!StringUtils.hasText(request.getTitle())) {
-			throw new BaseException("문서의 제목이 비어있습니다.");
-		}
-
-		//문서의 내용이 null이나 빈값이 아닌가?
-		if (!StringUtils.hasText(request.getContent())) {
-			throw new BaseException("문서의 내용이 비어있습니다.");
-		}
 
 		// 생성하려는 제목이 기존 내용과 중복될 여지가 있는가
 		if (documentContentRepository.existsByTitle(request.getTitle())) {

--- a/src/main/java/goorm/eagle7/stelligence/domain/notification/NotificationRepository.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/notification/NotificationRepository.java
@@ -6,7 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
-import goorm.eagle7.stelligence.domain.member.model.Member;
 import goorm.eagle7.stelligence.domain.notification.custom.CustomNotificationRepository;
 import goorm.eagle7.stelligence.domain.notification.model.Notification;
 
@@ -14,22 +13,22 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
 
 	/**
 	 * 특정 회원의 알림 목록 조회
-	 * @param member 회원
+	 * @param memberId 회원 ID
 	 * @return 알림 목록
 	 */
-	List<Notification> findByMember(Member member);
+	List<Notification> findByMemberId(Long memberId);
 
 	/**
 	 * 특정 회원의 모든 알림을 읽음 처리
-	 * @param member 회원
+	 * @param memberId 회원 ID
 	 */
 	@Modifying
-	@Query("update Notification n set n.isRead = true where n.member = :member")
-	void readAllNotificationsByMember(Member member);
+	@Query("update Notification n set n.isRead = true where n.memberId = :memberId")
+	void readAllNotificationsByMemberId(Long memberId);
 
 	/**
 	 * 특정 회원의 알림 목록 삭제
-	 * @param member 회원
+	 * @param memberId 회원 ID
 	 */
-	void deleteAllByMember(Member member);
+	void deleteAllByMemberId(Long memberId);
 }

--- a/src/main/java/goorm/eagle7/stelligence/domain/notification/NotificationService.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/notification/NotificationService.java
@@ -33,7 +33,7 @@ public class NotificationService {
 		Member member = memberRepository.findById(memberId)
 			.orElseThrow(() -> new BaseException("존재하지 않는 회원입니다."));
 
-		return notificationRepository.findByMember(member).stream()
+		return notificationRepository.findByMemberId(member.getId()).stream()
 			.map(NotificationResponse::of)
 			.toList();
 	}
@@ -50,7 +50,7 @@ public class NotificationService {
 		Notification notification = notificationRepository.findById(notificationId)
 			.orElseThrow(() -> new BaseException("존재하지 않는 알림입니다."));
 
-		if (!notification.getMember().equals(member)) {
+		if (!notification.getMemberId().equals(member.getId())) {
 			throw new BaseException("권한이 없습니다.");
 		}
 
@@ -65,7 +65,7 @@ public class NotificationService {
 		Member member = memberRepository.findById(memberId)
 			.orElseThrow(() -> new BaseException("존재하지 않는 회원입니다."));
 
-		notificationRepository.readAllNotificationsByMember(member);
+		notificationRepository.readAllNotificationsByMemberId(member.getId());
 	}
 
 	/**
@@ -80,7 +80,7 @@ public class NotificationService {
 		Notification notification = notificationRepository.findById(notificationId)
 			.orElseThrow(() -> new BaseException("존재하지 않는 알림입니다."));
 
-		if (!notification.getMember().equals(member)) {
+		if (!notification.getMemberId().equals(member.getId())) {
 			throw new BaseException("권한이 없습니다.");
 		}
 
@@ -95,6 +95,6 @@ public class NotificationService {
 		Member member = memberRepository.findById(memberId)
 			.orElseThrow(() -> new BaseException("존재하지 않는 회원입니다."));
 
-		notificationRepository.deleteAllByMember(member);
+		notificationRepository.deleteAllByMemberId(member.getId());
 	}
 }

--- a/src/main/java/goorm/eagle7/stelligence/domain/notification/custom/CustomNotificationRepositoryImpl.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/notification/custom/CustomNotificationRepositoryImpl.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.jdbc.core.JdbcTemplate;
 
 import lombok.RequiredArgsConstructor;
@@ -42,22 +41,7 @@ public class CustomNotificationRepositoryImpl implements CustomNotificationRepos
 			parameters.add(new Object[] {message, uri, memberId});
 		}
 
-		try {
-			// batchUpdate를 사용하여 여러 개의 알림을 한 번에 등록
-			jdbcTemplate.batchUpdate(INSERT_NOTIFICATIONS_SQL, parameters);
-
-		} catch (DataIntegrityViolationException e) {
-			// memberId가 존재하지 않는 경우 등록에 실패할 수 있음
-			log.warn("알림 등록 중 오류가 발생했습니다. {}", e.getMessage());
-
-			log.info("개별 알림 등록을 시도합니다.");
-			for (Object[] parameter : parameters) {
-				try {
-					jdbcTemplate.update(INSERT_NOTIFICATIONS_SQL, parameter);
-				} catch (DataIntegrityViolationException e2) {
-					log.warn("알림 등록 중 오류가 발생했습니다. MEMBER ID : {}", parameter[0]);
-				}
-			}
-		}
+		// batchUpdate를 사용하여 여러 개의 알림을 한 번에 등록
+		jdbcTemplate.batchUpdate(INSERT_NOTIFICATIONS_SQL, parameters);
 	}
 }

--- a/src/main/java/goorm/eagle7/stelligence/domain/notification/model/Notification.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/notification/model/Notification.java
@@ -1,14 +1,11 @@
 package goorm.eagle7.stelligence.domain.notification.model;
 
 import goorm.eagle7.stelligence.common.entity.BaseTimeEntity;
-import goorm.eagle7.stelligence.domain.member.model.Member;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -30,20 +27,8 @@ public class Notification extends BaseTimeEntity {
 	// 읽음 여부
 	private boolean isRead;
 
-	@ManyToOne
-	@JoinColumn(name = "member_id")
-	private Member member;
-
-	private Notification(String message, String uri, Member member) {
-		this.message = message;
-		this.uri = uri;
-		isRead = false;
-		this.member = member;
-	}
-
-	public static Notification createNotification(String content, String uri, Member member) {
-		return new Notification(content, uri, member);
-	}
+	//알림 대상 사용자
+	private Long memberId;
 
 	public void read() {
 		this.isRead = true;

--- a/src/test/java/goorm/eagle7/stelligence/domain/document/DocumentRequestValidatorTest.java
+++ b/src/test/java/goorm/eagle7/stelligence/domain/document/DocumentRequestValidatorTest.java
@@ -28,44 +28,6 @@ class DocumentRequestValidatorTest {
 	DocumentRequestValidator documentRequestValidator;
 
 	@Test
-	@DisplayName("제목이 null이거나 빈값인 경우")
-	void validateThrowsTitle() {
-		//given
-		DocumentCreateRequest request1 = DocumentCreateRequest.of(null, null, "content");
-		DocumentCreateRequest request2 = DocumentCreateRequest.of("  ", null, "content");
-
-		//then
-		assertThatThrownBy(
-			() -> documentRequestValidator.validate(request1))
-			.isInstanceOf(BaseException.class)
-			.hasMessage("문서의 제목이 비어있습니다.");
-
-		assertThatThrownBy(
-			() -> documentRequestValidator.validate(request2))
-			.isInstanceOf(BaseException.class)
-			.hasMessage("문서의 제목이 비어있습니다.");
-	}
-
-	@Test
-	@DisplayName("내용이 null이거나 빈값인 경우")
-	void validateThrowsContent() {
-		//given
-		DocumentCreateRequest request1 = DocumentCreateRequest.of("title", null, null);
-		DocumentCreateRequest request2 = DocumentCreateRequest.of("title", null, "           ");
-
-		//then
-		assertThatThrownBy(
-			() -> documentRequestValidator.validate(request1))
-			.isInstanceOf(BaseException.class)
-			.hasMessage("문서의 내용이 비어있습니다.");
-
-		assertThatThrownBy(
-			() -> documentRequestValidator.validate(request2))
-			.isInstanceOf(BaseException.class)
-			.hasMessage("문서의 내용이 비어있습니다.");
-	}
-
-	@Test
 	@DisplayName("제목이 이미 존재하는 경우")
 	void validateThrowsDuplicateTitle() {
 		//given

--- a/src/test/java/goorm/eagle7/stelligence/domain/notification/NotificationRepositoryTest.java
+++ b/src/test/java/goorm/eagle7/stelligence/domain/notification/NotificationRepositoryTest.java
@@ -31,22 +31,7 @@ class NotificationRepositoryTest {
 		List<Notification> notifications = notificationRepository.findAll();
 		assertThat(notifications)
 			.hasSize(3)
-			.extracting(Notification::getMember)
-			.extracting("id")
+			.extracting(Notification::getMemberId)
 			.containsExactlyInAnyOrder(1L, 2L, 4L);
-	}
-
-	@Test
-	@DisplayName("실패한 경우, 개별적으로 알림을 추가한다.")
-	void bulkInsertWithFail() {
-		notificationRepository.insertNotifications("message", "uri", Set.of(1L, 2L, 999L));
-
-		// then
-		List<Notification> notifications = notificationRepository.findAll();
-		assertThat(notifications)
-			.hasSize(2)
-			.extracting(Notification::getMember)
-			.extracting("id")
-			.containsExactlyInAnyOrder(1L, 2L);
 	}
 }


### PR DESCRIPTION
## 변경 내용 

- 이제는 Notification이 Member를 가지고 있지 않습니다.
- DB 레벨에서도 FK를 갖고 있지 않습니다.
- 따라서 쿼리 실패의 가능성도 줄어드므로, customNotificationRepository에서 예외처리관련 코드부분을 제거했습니다.

## 특이 사항

- 

## 체크리스트

- [x] PR 날리기 전에 main branch pull 받으셨나요?
- [x] application.properties 등 노출되지 않아야 하는 파일이 올라가지는 않았나요?
- [x] 다른 담당자 파일을 수정한 부분에 대해서 이야기 하셨나요?
- [x] 주석 "상세히" 다셨나요?
- [x] 제출하기 전에 테스트코드 돌려 보셨나요?

closes #267 
