### PR TITLE
[#275] refactor: Document Graph 탐색 시, root / depth 파라미터 삭제

### DIFF
--- a/src/main/java/goorm/eagle7/stelligence/domain/document/DocumentController.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/document/DocumentController.java
@@ -69,22 +69,17 @@ public class DocumentController {
 		return ResponseTemplate.ok(documentService.getDocumentContent(documentId, revision));
 	}
 
-	@Operation(summary = "문서 그래프 조회", description = "문서 그래프를 조회합니다.")
+	@Operation(summary = "문서 그래프 조회", description = "전체 문서 그래프를 조회합니다.")
 	@ApiResponse(
 		responseCode = "200",
 		description = "문서 그래프 조회 성공",
 		useReturnTypeSchema = true
 	)
 	@GetMapping
-	public ResponseTemplate<DocumentGraphResponse> getDocumentGraph(
-		@Parameter(description = "조회를 시작할 문서의 ID. 입력하지 않으면 최상위 문서를 조회합니다.", example = "1")
-		@RequestParam(value = "documentId", required = false) Long documentId,
-		@Parameter(description = "조회할 문서의 깊이. 입력하지 않으면 깊이가 0으로 설정됩니다.", example = "1")
-		@RequestParam(value = "depth", defaultValue = "0") int depth
-	) {
+	public ResponseTemplate<DocumentGraphResponse> getDocumentGraph() {
 
 		// documentId가 null이라면 최상위 문서로부터 조회합니다.
-		return ResponseTemplate.ok(documentService.getDocumentGraph(documentId, depth));
+		return ResponseTemplate.ok(documentService.getAllDocumentGraph());
 	}
 
 	@Operation(summary = "문서 노드 제목으로 조회", description = "문서 노드를 제목으로 조회합니다.")


### PR DESCRIPTION
## 변경 내용 

- Document Graph 탐색 시, root / depth 파라미터가 더 이상 필요 없어 삭제하였습니다.

## 특이 사항

- 

## 체크리스트

- [x] PR 날리기 전에 main branch pull 받으셨나요?
- [x] application.properties 등 노출되지 않아야 하는 파일이 올라가지는 않았나요?
- [x] 다른 담당자 파일을 수정한 부분에 대해서 이야기 하셨나요?
- [x] 주석 "상세히" 다셨나요?
- [x] 제출하기 전에 테스트코드 돌려 보셨나요?

closes #
