### PR TITLE
269 auth에서 memberinfo 받아지지 않음 -> 로그인 권한 로직 재구성

### DIFF
--- a/src/main/java/goorm/eagle7/stelligence/common/auth/filter/AuthFilter.java
+++ b/src/main/java/goorm/eagle7/stelligence/common/auth/filter/AuthFilter.java
@@ -2,9 +2,12 @@ package goorm.eagle7.stelligence.common.auth.filter;
 
 import java.io.IOException;
 
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
@@ -70,21 +73,38 @@ public class AuthFilter extends OncePerRequestFilter {
 				// SecurityContextHolder에 Authentication 저장
 				SecurityContextHolder.getContext().setAuthentication(authentication);
 
-				}
+			}
 
 		} catch (AuthenticationException e) {
 
-			// 로그아웃 시에는 토큰 검증이 필요 없음, 로그아웃 요청이 아니면 다시 같은 ex 발생
-			if (!(httpMethod.equals("POST") && uri.equals("/api/logout"))) {
-				log.debug("UsernameNotFoundException catched in AuthFilter : {}", e.getMessage());
-				throw new UsernameNotFoundException(e.getMessage());
+			// Login 필수인 경우, 재로그인 필요
+			if (!isMemberInfoRequired(httpMethod, uri)) {
+				throw new UsernameNotFoundException(ERROR_MESSAGE);
 			}
+
+			log.debug("[ex] 로그인 필수가 아닌 uri에서 로그인 사용자와 아닌 사용자를 구분. : {}", e.getMessage());
+			saveAuthenticationForNullMemberInfo();
 
 		}
 
 		// 다음 필터로 이동
 		filterChain.doFilter(request, response);
 
+	}
+
+	/**
+	 * <h2>SecurityContextHolder에 anonymousUser Authentication 저장</h2>
+	 * <p>- MemberInfo Resolver에서 anonymousUser 확인해 사용.</p>
+	 * TODO : anonymous token으로 사용 예정.
+	 */
+	private static void saveAuthenticationForNullMemberInfo() {
+		UserDetails userForNullMemberInfo =
+			User.withUsername("anonymousUser").password("")
+				.authorities("ROLE_USER").build();
+		AnonymousAuthenticationToken authentication = new AnonymousAuthenticationToken(
+			"anonymousUser", userForNullMemberInfo, userForNullMemberInfo.getAuthorities());
+
+		SecurityContextHolder.getContext().setAuthentication(authentication);
 	}
 
 	/**
@@ -96,7 +116,6 @@ public class AuthFilter extends OncePerRequestFilter {
 	 *  cookies, cookie가 null이 아니고, token이 있다면 Token 반환, 없다면 null
 	 * 	  -> accessToken이 null이면 refresh 토큰만 있는 경우
 	 * 	  -> token 유효성 검증 시 null도 검증하기 때문에 null로 설정.
-	 * @param cookieType accessToken, refreshToken 쿠키 이름
 	 * @return 해당 token value or null
 	 */
 	private String getActiveAccessToken() {
@@ -108,7 +127,7 @@ public class AuthFilter extends OncePerRequestFilter {
 					log.debug("accessCookie가 있습니다. 유효성 검사 진행");
 					// token 없으면 재로그인, 있으면 token 반환, 만료면 재발급
 					String accessToken = cookie.getValue();
-					if(StringUtils.hasText(accessToken)) {
+					if (StringUtils.hasText(accessToken)) {
 						return getAcccessTokenFromRefreshCookie();
 					}
 					return accessToken;
@@ -130,7 +149,7 @@ public class AuthFilter extends OncePerRequestFilter {
 			.getValue();
 
 		// refresh 토큰 없으면 재로그인, 있으면 재발급
-		if(!StringUtils.hasText(refreshToken)) {
+		if (!StringUtils.hasText(refreshToken)) {
 			throw new UsernameNotFoundException(ERROR_MESSAGE);
 		}
 
@@ -152,6 +171,10 @@ public class AuthFilter extends OncePerRequestFilter {
 	 */
 	private boolean isTokenValidationRequired(HttpServletRequest request) {
 		return !customRequestMatcher.matches(request);
+	}
+
+	private boolean isMemberInfoRequired(String httpMethod, String uri) {
+		return customRequestMatcher.matchesMemberInfoRequiredInPermitAll(httpMethod, uri);
 	}
 
 }

--- a/src/main/java/goorm/eagle7/stelligence/common/auth/filter/pathmatch/CustomRequestMatcher.java
+++ b/src/main/java/goorm/eagle7/stelligence/common/auth/filter/pathmatch/CustomRequestMatcher.java
@@ -17,7 +17,7 @@ public class CustomRequestMatcher implements RequestMatcher {
 	private final PermittedPathStore permittedPathStore;
 
 	/**
-	 * <h2>match 확인</h2>
+	 * <h2>permitAll match 확인</h2>
 	 * <p>요청의 httpMethod, uri 리소스 리스트 중 어느 하나라도 일치하는 게 있는지 확인</p>
 	 * @param request 요청
 	 * @return boolean 리소스 리스트에 있으면 true, 없으면 false
@@ -28,14 +28,18 @@ public class CustomRequestMatcher implements RequestMatcher {
 		String httpMethod = request.getMethod();
 		String uri = request.getRequestURI();
 
-		return permittedPathStore.exist(httpMethod, uri);
+		return permittedPathStore.isPermittedAll(httpMethod, uri);
+
 	}
 
-
-	// TODO : 추후에 필요하면 추가 구현
-	@Override
-	public MatchResult matcher(HttpServletRequest request) {
-		return org.springframework.security.web.util.matcher.RequestMatcher.super.matcher(request);
+	/**
+	 * <h2>permitAll 중 토큰 검증이 필요한지 확인</h2>
+	 * @param httpMethod
+	 * @param uri
+	 * @return
+	 */
+	public boolean matchesMemberInfoRequiredInPermitAll(String httpMethod, String uri) {
+		return permittedPathStore.isRequiredMemberInfo(httpMethod, uri);
 	}
 
 }

--- a/src/main/java/goorm/eagle7/stelligence/common/auth/filter/pathmatch/CustomRequestMatcher.java
+++ b/src/main/java/goorm/eagle7/stelligence/common/auth/filter/pathmatch/CustomRequestMatcher.java
@@ -27,6 +27,9 @@ public class CustomRequestMatcher implements RequestMatcher {
 
 		String httpMethod = request.getMethod();
 		String uri = request.getRequestURI();
+		if(matchesMemberInfoRequiredInPermitAll(httpMethod, uri)) {
+			return false;
+		}
 
 		return permittedPathStore.isPermittedAll(httpMethod, uri);
 

--- a/src/main/java/goorm/eagle7/stelligence/common/auth/filter/pathmatch/PermittedPathStore.java
+++ b/src/main/java/goorm/eagle7/stelligence/common/auth/filter/pathmatch/PermittedPathStore.java
@@ -18,7 +18,12 @@ import lombok.NoArgsConstructor;
 class PermittedPathStore {
 
 	private static final AntPathMatcher antPathMatcher = new AntPathMatcher();
-	private static final Set<RequestResource> REQUEST_RESOURCES =
+
+	/**
+	 * <h2>모든 허용 리소스 정보</h2>
+	 * <p>로그인 필요 없는 리소스(httpMethod, uri) 정보를 Set으로 저장</p>
+	 */
+	private static final Set<RequestResource> PERMITTED_RESOURCES =
 		Set.of(
 
 			RequestResource.of(HttpMethod.OPTIONS.name(), "/api/**"),
@@ -43,9 +48,6 @@ class PermittedPathStore {
 			RequestResource.of(HttpMethod.POST.name(), "/error/**"),
 			RequestResource.of(HttpMethod.OPTIONS.name(), "/error/**"),
 
-			// logout
-			// RequestResource.of(HttpMethod.POST.name(), "/api/logout"),
-
 			// login - dev
 			RequestResource.of(HttpMethod.POST.name(), "/api/login"),
 			RequestResource.of(HttpMethod.OPTIONS.name(), "/api/login"),
@@ -65,19 +67,29 @@ class PermittedPathStore {
 		);
 
 	/**
+	 * <h2>허용 리소스 중 로그인 정보를 받는 uri</h2>
+	 * <p>허용 리소스 중 로그인 필요한 리소스(httpMethod, uri) 정보를 Set으로 저장</p>
+	 */
+	private static final Set<RequestResource> MEMBERINFO_REQUIRED_RESOURCES =
+		Set.of(
+
+			RequestResource.of(HttpMethod.GET.name(), "/api/contributes/**/votes"),
+			RequestResource.of(HttpMethod.GET.name(), "/api/bookmarks/marked/**"),
+			RequestResource.of(HttpMethod.POST.name(), "/api/logout")
+
+		);
+
+	/**
 	 * <h2>허용하는 uri 확인</h2>
 	 * <p>- 요청의 httpMethod, uri가 리소스 리스트 중 어느 하나라도 일치하는 게 있는지 확인</p>
 	 * <p>- 허용하는 uri가 /**로 끝나면, basePath 비교</p>
-	 * @param httpMethod
-	 * @param uri
+	 * @param httpMethod httpMethod 타입
+	 * @param uri uri
 	 * @return boolean 리소스 리스트에 있으면 true, 없으면 false
 	 */
-	public boolean exist(String httpMethod, String uri) {
+	public boolean isPermittedAll(String httpMethod, String uri) {
 
-		// if(httpMethod.equals(HttpMethod.GET.name()) && uri.equals("/api/bookmarks/marked")) {
-		// 	return true;
-		// }
-		for (RequestResource resource : REQUEST_RESOURCES) {
+		for (RequestResource resource : PERMITTED_RESOURCES) {
 
 			String permittedHttpMethod = resource.getHttpMethod();
 			String permittedUri = resource.getUri();
@@ -89,4 +101,20 @@ class PermittedPathStore {
 		}
 		return false;
 	}
+
+	public boolean isRequiredMemberInfo(String httpMethod, String uri) {
+
+		for (RequestResource resource : MEMBERINFO_REQUIRED_RESOURCES) {
+
+			String permittedHttpMethod = resource.getHttpMethod();
+			String permittedUri = resource.getUri();
+
+			if (permittedHttpMethod.equals(httpMethod) &&
+				antPathMatcher.match(permittedUri, uri)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
 }

--- a/src/main/java/goorm/eagle7/stelligence/common/auth/filter/pathmatch/ResourceAntPathMatcher.java
+++ b/src/main/java/goorm/eagle7/stelligence/common/auth/filter/pathmatch/ResourceAntPathMatcher.java
@@ -23,7 +23,7 @@ public class ResourceAntPathMatcher extends AntPathMatcher {
 	@Override
 	public boolean match(String httpMethod, String uri) {
 
-		return permittedPathStore.exist(httpMethod, uri);
+		return permittedPathStore.isPermittedAll(httpMethod, uri);
 
 	}
 

--- a/src/main/java/goorm/eagle7/stelligence/common/auth/memberinfo/MemberInfoArgumentResolver.java
+++ b/src/main/java/goorm/eagle7/stelligence/common/auth/memberinfo/MemberInfoArgumentResolver.java
@@ -14,6 +14,7 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 
 import goorm.eagle7.stelligence.domain.member.model.Role;
 import jakarta.annotation.Nullable;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  *  <h2>Auth 애노테이션에서 사용할 객체 mapping (MemberInfo)</h2>
@@ -21,6 +22,7 @@ import jakarta.annotation.Nullable;
  *  <p>- SecurityContextHolder(ThreadLocal)에서 User 객체를 가져와서 MemberInfo 객체 생성해 반환</p>
  *  <p>- MemberInfo: memberId, role을 가지고 있는 객체</p>
  */
+@Slf4j
 @Component
 public class MemberInfoArgumentResolver
 	implements HandlerMethodArgumentResolver {
@@ -50,6 +52,12 @@ public class MemberInfoArgumentResolver
 
 		if(SecurityContextHolder.getContext()
 			.getAuthentication().getPrincipal() instanceof User user){
+
+			if(user.getUsername().equals("anonymousUser")){
+				log.debug("anonymousUser, @Auth에 null 반환");
+				return null;
+			}
+
 			long memberId = Long.parseLong(user.getUsername());
 
 			Collection<? extends GrantedAuthority> authorities = user.getAuthorities();

--- a/src/main/java/goorm/eagle7/stelligence/common/auth/oauth/handler/OAuth2LogoutCustomHandler.java
+++ b/src/main/java/goorm/eagle7/stelligence/common/auth/oauth/handler/OAuth2LogoutCustomHandler.java
@@ -28,13 +28,19 @@ public class OAuth2LogoutCustomHandler implements LogoutHandler {
 	public void logout(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
 
 		// Authentication에서 사용자 정보 추출, name == memeberId
-		if (authentication == null) {
-			// 로그인하지 않은 사용자가 로그아웃 요청 시, 아무것도 하지 않음
-		} else if (authentication.getPrincipal() instanceof User user) {
-			Long memberId = Long.parseLong(user.getUsername());
-			loginService.logout(memberId);
-		}
+		if (authentication != null && authentication.getPrincipal() instanceof User user) {
 
+			String username = user.getUsername();
+
+			// 로그인하지 않은 사용자가 로그아웃 요청 시, 아무것도 하지 않음
+			// 권한 필요 없는 uri에서 로그아웃 요청 시, username == anonymousUser, 아무것도 하지 않음
+			if (!username.equals("anonymousUser")) {
+
+				Long memberId = Long.parseLong(username);
+				loginService.logout(memberId);
+
+			}
+		}
 	}
 
 }

--- a/src/test/java/goorm/eagle7/stelligence/common/auth/filter/pathmatch/PermittedPathStoreTest.java
+++ b/src/test/java/goorm/eagle7/stelligence/common/auth/filter/pathmatch/PermittedPathStoreTest.java
@@ -27,7 +27,7 @@ class PermittedPathStoreTest {
 		String uri = "/api/documents";
 
 		// when
-		boolean result = permittedPathStore.exist(httpMethod, uri);
+		boolean result = permittedPathStore.isPermittedAll(httpMethod, uri);
 
 		// then
 		assertThat(result).isTrue();
@@ -43,7 +43,7 @@ class PermittedPathStoreTest {
 		String uri = "/api/documents/search?query=1";
 
 		// when
-		boolean result = permittedPathStore.exist(httpMethod, uri);
+		boolean result = permittedPathStore.isPermittedAll(httpMethod, uri);
 
 		// then
 		assertThat(result).isTrue();
@@ -59,7 +59,7 @@ class PermittedPathStoreTest {
 		String uri = "/api/documents";
 
 		// when
-		boolean result = permittedPathStore.exist(httpMethod, uri);
+		boolean result = permittedPathStore.isPermittedAll(httpMethod, uri);
 
 		// then
 		assertThat(result).isFalse();
@@ -75,7 +75,7 @@ class PermittedPathStoreTest {
 		String uri = "/api/notin";
 
 		// when
-		boolean result = permittedPathStore.exist(httpMethod, uri);
+		boolean result = permittedPathStore.isPermittedAll(httpMethod, uri);
 
 		// then
 		assertThat(result).isFalse();
@@ -91,7 +91,7 @@ class PermittedPathStoreTest {
 		String uri = "/api/document";
 
 		// when
-		boolean result = permittedPathStore.exist(httpMethod, uri);
+		boolean result = permittedPathStore.isPermittedAll(httpMethod, uri);
 
 		// then
 		assertThat(result).isFalse();
@@ -107,7 +107,7 @@ class PermittedPathStoreTest {
 		String uri = "/notin";
 
 		// when
-		boolean result = permittedPathStore.exist(httpMethod, uri);
+		boolean result = permittedPathStore.isPermittedAll(httpMethod, uri);
 
 		// then
 		assertThat(result).isFalse();
@@ -123,7 +123,7 @@ class PermittedPathStoreTest {
 		String uri = "/api/login";
 
 		// when
-		boolean result = permittedPathStore.exist(httpMethod, uri);
+		boolean result = permittedPathStore.isPermittedAll(httpMethod, uri);
 
 		// then
 		assertThat(result).isTrue();
@@ -139,7 +139,75 @@ class PermittedPathStoreTest {
 		String uri = "/api/members/me/nickname";
 
 		// when
-		boolean result = permittedPathStore.exist(httpMethod, uri);
+		boolean result = permittedPathStore.isPermittedAll(httpMethod, uri);
+
+		// then
+		assertThat(result).isTrue();
+
+	}
+
+	/** existMemberInfoRequired 메서드 테스트 */
+
+	@Test
+	@DisplayName("[성공] uri **에 많은 것이 있는 경우 - /api/contibutes/**/votes - existMemberInfoRequired")
+	void existApiContributesVotesTrue() {
+
+		// given
+		String httpMethod = "GET";
+		String uri = "/api/contributes/1/4/random/44//votes";
+
+		// when
+		boolean result = permittedPathStore.isRequiredMemberInfo(httpMethod, uri);
+
+		// then
+		assertThat(result).isTrue();
+
+	}
+
+	/** existMemberInfoRequired 메서드 테스트 */
+
+	@Test
+	@DisplayName("[성공] **에 아무것도 없는 경우 - /api/contributes/**/votes 경우 - existMemberInfoRequired")
+	void existMemberInfoRequiredApiContributesVotesTrue() {
+
+		// given
+		String httpMethod = "GET";
+		String uri = "/api/contributes/votes";
+
+		// when
+		boolean result = permittedPathStore.isRequiredMemberInfo(httpMethod, uri);
+
+		// then
+		assertThat(result).isTrue();
+
+	}
+
+	@Test
+	@DisplayName("[예외] 메서드가 다른 경우, /api/contributes/**/votes 경우 - existMemberInfoRequired")
+	void existMemberInfoRequiredApiContributesVotesFalse() {
+
+		// given
+		String httpMethod = "POST";
+		String uri = "/api/contributes/votes";
+
+		// when
+		boolean result = permittedPathStore.isRequiredMemberInfo(httpMethod, uri);
+
+		// then
+		assertThat(result).isFalse();
+
+	}
+
+	@Test
+	@DisplayName("[성공] /api/bookmarks/marked 경우")
+	void existMemberInfoRequiredApiBookmarksMarkedTrue() {
+
+		// given
+		String httpMethod = "GET";
+		String uri = "/api/bookmarks/marked";
+
+		// when
+		boolean result = permittedPathStore.isRequiredMemberInfo(httpMethod, uri);
 
 		// then
 		assertThat(result).isTrue();


### PR DESCRIPTION
## 변경 내용 
- permitAll인 uri에서는 Authentication을 저장하는 어떤 로직도 수행하지 않아서 @Auth 바인딩 시 아예 500 에러가 나고, null이 받아와지지 않아서, @Auth를 사용하는 uri라면 null / MemberInfo 둘 중 하나를 받게 하려 함.

- 바꿔야 하는 이유
  - 기존 권한 필요 없는 url (security의 permitAll 이용) : get, /api/documents/**, /api/contributes/**, /api/comments/**, /api/debates/**
  - 권한 필요 없는 url에서는 @Auth 이용하지 않는다 가정
  - get, /api/contributes/**/votes 에서도 @Auth 사용, 이 경우 token 검증하는 로직을 아예 거치지 않아 @Auth 매핑하지 않음. 
  - 해당 로직 변경 
    - -> 기존: 권한 필요한 uri에서 토큰 검증 후 검증 실패 시 logout uri 제외하고 401 
    - -> 변경 내용: 권한 필요 없는 uri 중 @Auth 필요한 곳 제외, 해당 uri를 검증, 검증 실패한 uri 중 MEMBERINFO_REQUIRED_RESOURCES에 있던 uri라면 임의의 userId를 넣어준 후, Resolver에서 해당 userId인 경우 null 반환

- pathStore에서 pathSet 따로 관리
- get votes, get bookmark/marked , logout 함께 설정

## 특이 사항
- 추후 security anonymous 적절하면 적용 예정.
- 권한 있어야 하는 곳 중 권한 없이도 볼 수 있는 곳에 대한 처리 필요.
- 권한 Uri 세부 조정 필요.
- 추후 yml으로 관리 필요.

## 체크리스트
- [X] PR 날리기 전에 main branch pull 받으셨나요?
- [X] application.properties 등 노출되지 않아야 하는 파일이 올라가지는 않았나요?
- [X] 다른 담당자 파일을 수정한 부분에 대해서 이야기 하셨나요?
- [X] 주석 "상세히" 다셨나요?
- [X] 제출하기 전에 테스트코드 돌려 보셨나요?

closes #269 
