### PR TITLE
[#232] feat: 수정요청 대기중인 문서에 대한 검증 로직 추가

### DIFF
--- a/src/main/java/goorm/eagle7/stelligence/domain/contribute/ContributeRequestValidator.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/contribute/ContributeRequestValidator.java
@@ -16,6 +16,7 @@ import goorm.eagle7.stelligence.domain.amendment.dto.AmendmentRequest;
 import goorm.eagle7.stelligence.domain.amendment.model.AmendmentType;
 import goorm.eagle7.stelligence.domain.contribute.dto.ContributeRequest;
 import goorm.eagle7.stelligence.domain.contribute.model.ContributeStatus;
+import goorm.eagle7.stelligence.domain.debate.model.Debate;
 import goorm.eagle7.stelligence.domain.debate.repository.DebateRepository;
 import goorm.eagle7.stelligence.domain.document.content.DocumentContentRepository;
 import goorm.eagle7.stelligence.domain.document.content.model.Document;
@@ -67,7 +68,6 @@ public class ContributeRequestValidator {
 
 		// 해당 document에 대한 토론이 진행중이거나, 수정요청 대기중인가?
 		checkDebate(request, loginMemberId);
-
 
 		//수정하고자 하는 section들이 document에 존재하는가
 		List<Long> sectionIds = sectionRepository.findSectionIdByVersion(document,
@@ -136,18 +136,27 @@ public class ContributeRequestValidator {
 		debateRepository.findLatestDebateByDocumentId(request.getDocumentId()).ifPresent(
 			debate -> {
 				// 토론이 진행중인가?
-				if (debate.isOnDebate()) {
-					throw new BaseException("해당 문서에 대한 토론이 진행중입니다. debateId=" + debate.getId());
-				}
+				checkIsOnDebate(debate);
 				// 토론이 종료된 후 토론 참여자를 위한 수정요청 대기중인가?
-				if (debate.isPendingForContribute()
-					// 다른 토론에서 파생된 수정요청을 보내는 경우
-					&& (!debate.getId().equals(request.getRelatedDebateId())
-					// 토론 참여자가 아닌 사람이 수정요청을 보내는 경우
-					|| !debate.hasPermissionToWriteDrivenContribute(loginMemberId))) {
-					throw new BaseException("최근 종료된 토론 참여자를 위한 수정요청 대기중입니다. debateId=" + debate.getId());
-				}
+				checkDebateIsPendingForDebater(debate, request.getRelatedDebateId(), loginMemberId);
 			}
 		);
 	}
+
+	void checkIsOnDebate(Debate debate) {
+		if (debate.isOnDebate()) {
+			throw new BaseException("해당 문서에 대한 토론이 진행중입니다. debateId=" + debate.getId());
+		}
+	}
+	
+	void checkDebateIsPendingForDebater(Debate debate, Long relatedDebateId, Long loginMemberId) {
+		if (debate.isPendingForContribute()
+			// 다른 토론에서 파생된 수정요청을 보내는 경우
+			&& (!debate.getId().equals(relatedDebateId)
+			// 토론 참여자가 아닌 사람이 수정요청을 보내는 경우
+			|| !debate.hasPermissionToWriteDrivenContribute(loginMemberId))) {
+			throw new BaseException("최근 종료된 토론 참여자를 위한 수정요청 대기중입니다. debateId=" + debate.getId());
+		}
+	}
+
 }

--- a/src/main/java/goorm/eagle7/stelligence/domain/contribute/ContributeService.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/contribute/ContributeService.java
@@ -46,7 +46,7 @@ public class ContributeService {
 	@Transactional
 	public ContributeResponse createContribute(ContributeRequest contributeRequest, Long loginMemberId) {
 
-		contributeRequestValidator.validate(contributeRequest);
+		contributeRequestValidator.validate(contributeRequest, loginMemberId);
 
 		Member member = memberRepository.findById(loginMemberId).orElseThrow(
 			() -> new BaseException("존재하지 않는 회원의 요청입니다. 사용자 ID: " + loginMemberId)

--- a/src/test/java/goorm/eagle7/stelligence/domain/contribute/ContributeRequestValidatorTest.java
+++ b/src/test/java/goorm/eagle7/stelligence/domain/contribute/ContributeRequestValidatorTest.java
@@ -4,6 +4,7 @@ import static goorm.eagle7.stelligence.config.mockdata.TestFixtureGenerator.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -19,6 +20,7 @@ import goorm.eagle7.stelligence.api.exception.BaseException;
 import goorm.eagle7.stelligence.domain.amendment.dto.AmendmentRequest;
 import goorm.eagle7.stelligence.domain.amendment.model.AmendmentType;
 import goorm.eagle7.stelligence.domain.contribute.dto.ContributeRequest;
+import goorm.eagle7.stelligence.domain.debate.model.Debate;
 import goorm.eagle7.stelligence.domain.debate.model.DebateStatus;
 import goorm.eagle7.stelligence.domain.debate.repository.DebateRepository;
 import goorm.eagle7.stelligence.domain.document.content.DocumentContentRepository;
@@ -45,6 +47,7 @@ class ContributeRequestValidatorTest {
 	void validateSuccess() {
 
 		Document targetDocument = document(1L, member(1L, "pete"), "title", 1L, null);
+		Long loginMemberId = 2L;
 
 		AmendmentRequest a1 = new AmendmentRequest(1L, AmendmentType.DELETE, Heading.H2, "title",
 			"content", 0);
@@ -68,10 +71,11 @@ class ContributeRequestValidatorTest {
 		when(sectionRepository.findSectionIdByVersion(any(), any())).thenReturn(List.of(1L, 2L, 3L));
 		when(documentContentRepository.findByTitle("title")).thenReturn(Optional.of(targetDocument));
 		when(contributeRepository.existsDuplicateRequestedDocumentTitle("title")).thenReturn(false);
+		when(debateRepository.findLatestDebateByDocumentId(1L)).thenReturn(Optional.empty());
 
 		//then
 		assertThatNoException().isThrownBy(
-			() -> contributeRequestValidator.validate(contributeRequest));
+			() -> contributeRequestValidator.validate(contributeRequest, loginMemberId));
 
 	}
 
@@ -81,12 +85,13 @@ class ContributeRequestValidatorTest {
 		//given
 		ContributeRequest contributeRequest = new ContributeRequest("title", "description", Collections.emptyList(), 1L,
 			"title", 2L, null);
+		Long loginMemberId = 2L;
 
 		//when
 		when(documentContentRepository.findById(1L)).thenReturn(Optional.empty());
 
 		assertThatThrownBy(
-			() -> contributeRequestValidator.validate(contributeRequest)
+			() -> contributeRequestValidator.validate(contributeRequest, loginMemberId)
 		).isInstanceOf(BaseException.class).hasMessage("문서가 존재하지 않습니다. documentId=1");
 	}
 
@@ -96,6 +101,7 @@ class ContributeRequestValidatorTest {
 		//given
 		ContributeRequest contributeRequest = new ContributeRequest("title", "description", Collections.emptyList(), 1L,
 			"title", 2L, null);
+		Long loginMemberId = 2L;
 
 		//when
 		when(documentContentRepository.findById(1L)).thenReturn(Optional.of(mock(Document.class)));
@@ -103,7 +109,7 @@ class ContributeRequestValidatorTest {
 
 		//then
 		assertThatThrownBy(
-			() -> contributeRequestValidator.validate(contributeRequest)
+			() -> contributeRequestValidator.validate(contributeRequest, loginMemberId)
 		).isInstanceOf(BaseException.class).hasMessage("이미 해당 문서에 대한 수정요청이 존재합니다. documentId=1");
 	}
 
@@ -111,18 +117,75 @@ class ContributeRequestValidatorTest {
 	@DisplayName("documentId에 해당하는 문서에 대한 토론이 진행중인 경우")
 	void debating() {
 		//given
-		ContributeRequest contributeRequest = new ContributeRequest("title", "description", Collections.emptyList(), 1L,
+		ContributeRequest contributeRequest = new ContributeRequest("title", "description",
+			Collections.emptyList(), 1L,
 			"title", 2L, null);
+		Long loginMemberId = 2L;
+		Debate debate = debate(3L, null, DebateStatus.OPEN, LocalDateTime.now(), 1);
 
 		//when
 		when(documentContentRepository.findById(1L)).thenReturn(Optional.of(mock(Document.class)));
 		when(contributeRepository.existsByDocumentAndStatus(any(), any())).thenReturn(false);
-		when(debateRepository.existsByContributeDocumentIdAndStatus(1L, DebateStatus.OPEN))
-			.thenReturn(true);
+		when(debateRepository.findLatestDebateByDocumentId(1L)).thenReturn(Optional.of(debate));
 
 		//then
-		assertThatThrownBy(() -> contributeRequestValidator.validate(contributeRequest))
-			.isInstanceOf(BaseException.class).hasMessage("해당 문서에 대한 토론이 진행중입니다. documentId=1");
+		assertThat(debate.isOnDebate()).isTrue();
+		assertThatThrownBy(() -> contributeRequestValidator.validate(contributeRequest, loginMemberId))
+			.isInstanceOf(BaseException.class).hasMessage("해당 문서에 대한 토론이 진행중입니다. debateId=" + debate.getId());
+	}
+
+	@Test
+	@DisplayName("토론 종료 후 수정요청 대기중에 다른 토론에서 수정요청을 하려는 경우")
+	void debatePendingRequestOtherDebate() {
+		//given
+		Long loginMemberId = 2L;
+		Debate pendingDebate = debate(3L, null, DebateStatus.CLOSED,
+			LocalDateTime.now(), 1);
+		Debate noPendingDebate = debate(4L, null, DebateStatus.CLOSED,
+			LocalDateTime.now().minusDays(1L), 1);
+
+		ContributeRequest contributeRequest = new ContributeRequest("title", "description",
+			Collections.emptyList(), 1L,
+			"title", 2L, noPendingDebate.getId());
+
+		//when
+		when(documentContentRepository.findById(1L)).thenReturn(Optional.of(mock(Document.class)));
+		when(contributeRepository.existsByDocumentAndStatus(any(), any())).thenReturn(false);
+		when(debateRepository.findLatestDebateByDocumentId(1L)).thenReturn(Optional.of(pendingDebate));
+
+		//then
+		assertThat(pendingDebate.isPendingForContribute()).isTrue();
+		assertThat(pendingDebate.getId()).isNotEqualTo(contributeRequest.getRelatedDebateId());
+		assertThatThrownBy(() -> contributeRequestValidator.validate(contributeRequest, loginMemberId))
+			.isInstanceOf(BaseException.class)
+			.hasMessage("최근 종료된 토론 참여자를 위한 수정요청 대기중입니다. debateId=" + pendingDebate.getId());
+	}
+
+	@Test
+	@DisplayName("토론 종료 후 수정요청 대기중에 토론에 참여하지 않았던 회원이 수정요청을 하려는 경우")
+	void debatePendingRequestFromNoCommenter() {
+		//given
+		Long loginMemberId = 2L;
+		Debate pendingDebate = debate(3L, null, DebateStatus.CLOSED,
+			LocalDateTime.now(), 1);
+
+		ContributeRequest contributeRequest = new ContributeRequest("title", "description",
+			Collections.emptyList(), 1L,
+			"title", 2L, pendingDebate.getId());
+
+		//when
+		when(documentContentRepository.findById(1L)).thenReturn(Optional.of(mock(Document.class)));
+		when(contributeRepository.existsByDocumentAndStatus(any(), any())).thenReturn(false);
+		when(debateRepository.findLatestDebateByDocumentId(1L)).thenReturn(Optional.of(pendingDebate));
+
+		//then
+		assertThat(pendingDebate.isPendingForContribute()).isTrue();
+		assertThat(pendingDebate.getId()).isEqualTo(contributeRequest.getRelatedDebateId());
+		assertThat(pendingDebate.hasPermissionToWriteDrivenContribute(loginMemberId)).isFalse();
+
+		assertThatThrownBy(() -> contributeRequestValidator.validate(contributeRequest, loginMemberId))
+			.isInstanceOf(BaseException.class)
+			.hasMessage("최근 종료된 토론 참여자를 위한 수정요청 대기중입니다. debateId=" + pendingDebate.getId());
 	}
 
 	@Test
@@ -132,6 +195,7 @@ class ContributeRequestValidatorTest {
 
 		ContributeRequest contributeRequest = new ContributeRequest("title", "description", Collections.emptyList(), 1L,
 			"newTitle", 2L, null);
+		Long loginMemberId = 2L;
 
 		//when
 		when(documentContentRepository.findById(1L)).thenReturn(Optional.of(mock(Document.class)));
@@ -140,7 +204,7 @@ class ContributeRequestValidatorTest {
 		when(documentContentRepository.findByTitle("newTitle")).thenReturn(Optional.of(targetDocument));
 
 		assertThatThrownBy(
-			() -> contributeRequestValidator.validate(contributeRequest)
+			() -> contributeRequestValidator.validate(contributeRequest, loginMemberId)
 		).isInstanceOf(BaseException.class).hasMessage("이미 해당 제목을 가진 문서가 존재합니다. title=newTitle");
 
 	}
@@ -150,6 +214,7 @@ class ContributeRequestValidatorTest {
 	void duplicateDocumentTitle2() {
 		ContributeRequest contributeRequest = new ContributeRequest("title", "description", Collections.emptyList(), 1L,
 			"newTitle", 2L, null);
+		Long loginMemberId = 2L;
 
 		//when
 		when(documentContentRepository.findById(1L)).thenReturn(Optional.of(mock(Document.class)));
@@ -159,7 +224,7 @@ class ContributeRequestValidatorTest {
 		when(contributeRepository.existsDuplicateRequestedDocumentTitle("newTitle")).thenReturn(true);
 
 		assertThatThrownBy(
-			() -> contributeRequestValidator.validate(contributeRequest)
+			() -> contributeRequestValidator.validate(contributeRequest, loginMemberId)
 		).isInstanceOf(BaseException.class).hasMessage("해당 제목으로 변경을 요청중인 수정요청이 이미 존재합니다. title=newTitle");
 	}
 
@@ -171,6 +236,7 @@ class ContributeRequestValidatorTest {
 			"content", 1);
 		ContributeRequest contributeRequest = new ContributeRequest("title", "description", List.of(a1), 1L, "title",
 			2L, null);
+		Long loginMemberId = 2L;
 
 		//when
 		when(documentContentRepository.findById(1L)).thenReturn(Optional.of(mock(Document.class)));
@@ -179,7 +245,7 @@ class ContributeRequestValidatorTest {
 
 		//then
 		assertThatThrownBy(
-			() -> contributeRequestValidator.validate(contributeRequest)
+			() -> contributeRequestValidator.validate(contributeRequest, loginMemberId)
 		).isInstanceOf(BaseException.class).hasMessage("해당 문서에 존재하지 않는 섹션을 수정하려고 합니다. sectionId=1");
 	}
 
@@ -193,6 +259,7 @@ class ContributeRequestValidatorTest {
 			"content", 1);
 		ContributeRequest contributeRequest = new ContributeRequest("title", "description", List.of(a1, a2), 1L,
 			"title", 2L, null);
+		Long loginMemberId = 2L;
 
 		//when
 		when(documentContentRepository.findById(1L)).thenReturn(Optional.of(mock(Document.class)));
@@ -201,7 +268,7 @@ class ContributeRequestValidatorTest {
 
 		//then
 		assertThatThrownBy(
-			() -> contributeRequestValidator.validate(contributeRequest)
+			() -> contributeRequestValidator.validate(contributeRequest, loginMemberId)
 		).isInstanceOf(BaseException.class).hasMessage("중복된 생성 순서가 존재합니다. sectionId=1");
 	}
 
@@ -215,6 +282,7 @@ class ContributeRequestValidatorTest {
 			"content", 1);
 		ContributeRequest contributeRequest = new ContributeRequest("title", "description", List.of(a1, a2), 1L,
 			"title", 2L, null);
+		Long loginMemberId = 2L;
 
 		//when
 		when(documentContentRepository.findById(1L)).thenReturn(Optional.of(mock(Document.class)));
@@ -223,7 +291,7 @@ class ContributeRequestValidatorTest {
 
 		//then
 		assertThatThrownBy(
-			() -> contributeRequestValidator.validate(contributeRequest)
+			() -> contributeRequestValidator.validate(contributeRequest, loginMemberId)
 		).isInstanceOf(BaseException.class).hasMessage("생성 순서가 순차적이지 않습니다.");
 	}
 }


### PR DESCRIPTION
## 변경 내용 

- 아래와 같은 조건에 따라 검증을 수행하도록 ContributeRequestValidator를 수정하였습니다.

1. 토론이 진행중인가? - 수정요청 불가
1. 토론이 종료된 후 토론 참여자를 위한 수정요청 대기중인가?
    1. 다른 토론에서 파생된 수정요청을 보내는 경우 - 수정요청 불가
    1. 토론 참여자가 아닌 사람이 수정요청을 보내는 경우 - 수정요청 불가

## 특이 사항

- 메서드 이름이 생각이 잘 안나서 checkDebate로 하였습니다..
- 더 좋은 이름이 있다면 추천 부탁드립니다!!

## 체크리스트

- [x] PR 날리기 전에 main branch pull 받으셨나요?
- [x] application.properties 등 노출되지 않아야 하는 파일이 올라가지는 않았나요?
- [x] 다른 담당자 파일을 수정한 부분에 대해서 이야기 하셨나요?
- [x] 주석 "상세히" 다셨나요?
- [x] 제출하기 전에 테스트코드 돌려 보셨나요?

closes #
