### PR TITLE
294 닉네임 최대 15자 제한

### DIFF
--- a/src/main/java/goorm/eagle7/stelligence/common/util/UniqueNicknameGenerator.java
+++ b/src/main/java/goorm/eagle7/stelligence/common/util/UniqueNicknameGenerator.java
@@ -5,11 +5,14 @@ import java.util.function.Predicate;
 
 import org.springframework.util.StringUtils;
 
-import goorm.eagle7.stelligence.api.exception.BaseException;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public final class UniqueNicknameGenerator {
+
+	private static final int MAX_UUID_LENGTH = 5;
+	private static final int MAX_ATTEMPT = 10;
+	private static final int MAX_NICKNAME_LENGTH = 15;
 
 	private UniqueNicknameGenerator() {
 		throw new IllegalStateException("Utility class");
@@ -18,34 +21,53 @@ public final class UniqueNicknameGenerator {
 	/**
 	 * <h2>유일한 닉네임 생성</h2>
 	 * <p>- 중복이 아닐 때까지 닉네임에 랜덤 숫자를 추가해 새로운 닉네임 생성.</p>
-	 * <p>- 최대 시도 횟수는 10회로 제한.</p>
+	 * <p>- 최대 시도 횟수는 10회, 최대 15자.</p>
 	 * <p>- Predicate 인터페이스를 사용해 닉네임의 중복 여부를 외부에서 결정할 수 있도록 함.</p>
 	 * @param baseNickname 기본 닉네임
 	 * @param isDuplicate 중복 검사를 수행하는 함수
 	 * @return 중복되지 않는 닉네임(랜덤 문자는 최대 5자리)
-	 */ // TODO 파라미터는 변하는 게 좋지 않음!
+	 */
 	public static String generateUniqueNickname(String baseNickname, Predicate<String> isDuplicate) {
 
+		// 기본 닉네임이 없으면 "은하"로 설정
+		// 파라미터 보호 및 새로운 시도 시, baseNickname에 붙는 문자만 다르게 하기 위해 baseNickname과 nickname 분리
 		baseNickname = StringUtils.hasText(baseNickname) ? baseNickname : "은하";
+
 		String nickname = baseNickname;
 
-		for (int attempt = 0; attempt < 10; attempt++) {
-			if (!isDuplicate.test(nickname)) {
+		for (int attempt = 0; attempt < MAX_ATTEMPT; attempt++) {
+
+			// 중복이 아니고, 15자 이내 닉네임이면 반환
+			if (nickname.length() <= MAX_NICKNAME_LENGTH
+				&& !isDuplicate.test(nickname)) {
 				return nickname;
 			}
-			nickname = generateNewNickname(baseNickname);
-		}
 
-		throw new BaseException("닉네임 생성에 실패했습니다. 최대 시도 횟수를 초과했습니다.");
+			// 새로운 닉네임 창출
+			nickname = generateNewNickname(baseNickname);
+
+		}
+		return nickname;
 	}
 
 	private static String generateNewNickname(String baseNickname) {
 
-		// 랜덤 숫자 5자리 생성
-		String uuid = UUID.randomUUID().toString().substring(0, 5);
+		// 15자 이상인 경우, 10자로 자르기
+		if (baseNickname.length() >= MAX_NICKNAME_LENGTH) {
+			baseNickname = baseNickname.substring(0, MAX_NICKNAME_LENGTH - MAX_UUID_LENGTH);
+		}
+		// 랜덤 문자 5자리 생성
+		String uuid = UUID.randomUUID().toString().substring(0, MAX_UUID_LENGTH);
+
+		// 닉네임 생성, 15자 초과 시, 15자로 자르기
 		String newNickname = baseNickname + uuid;
+		if (newNickname.length() > MAX_NICKNAME_LENGTH) {
+			newNickname = newNickname.substring(0, MAX_NICKNAME_LENGTH);
+		}
+
 		log.trace(" 닉네임 중복으로 새로 생성한 닉네임: {}", newNickname);
 		return newNickname;
+
 	}
 
 }

--- a/src/main/java/goorm/eagle7/stelligence/domain/member/MemberService.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/member/MemberService.java
@@ -87,6 +87,10 @@ public class MemberService {
 			throw new BaseException("이미 사용 중인 닉네임입니다. nickname=" + nickname);
 		}
 
+		if(nickname.length() > 15) {
+			throw new BaseException("닉네임은 15자 이하로 입력해주세요.");
+		}
+
 		// 사용 중이지 않은 닉네임이면 닉네임 변경
 		member.updateNickname(nickname);
 

--- a/src/main/java/goorm/eagle7/stelligence/domain/member/model/Member.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/member/model/Member.java
@@ -41,10 +41,10 @@ public class Member extends BaseTimeEntity {
 	private boolean active; // default: true, for soft delete
 
 	// social login 시 받아오는 정보
-	private String nickname;
+	private String nickname; // TODO 최대 15자 제한 필요
 	private String email;
 	private String imageUrl;
-	private String socialId; // unique지만, DB에서는 unique 제약 조건을 걸지 않음.
+	private String socialId;
 	@Enumerated(EnumType.STRING)
 	private SocialType socialType;
 

--- a/src/test/java/goorm/eagle7/stelligence/common/util/UniqueNicknameGeneratorTest.java
+++ b/src/test/java/goorm/eagle7/stelligence/common/util/UniqueNicknameGeneratorTest.java
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import goorm.eagle7.stelligence.api.exception.BaseException;
 import goorm.eagle7.stelligence.domain.member.MemberRepository;
 import lombok.extern.slf4j.Slf4j;
 
@@ -49,7 +48,7 @@ class UniqueNicknameGeneratorTest {
 	 * <p>- 중복이 아닐 때까지 닉네임에 랜덤 숫자를 변경해 새로운 닉네임 생성.</p>
 	 */
 	@Test
-	@DisplayName("[정상] 중복 닉네임인 경우, 랜덤 숫자가 추가된 새로운 닉네임 생성(9 중복) - generateUniqueNickname")
+	@DisplayName("[정상] 중복 닉네임이고, 2자인 경우, 랜덤 숫자가 추가된 새로운 닉네임 생성(9 중복) - generateUniqueNickname")
 	void generateUniqueNicknameWithRandomNumber() {
 
 		// given
@@ -66,9 +65,10 @@ class UniqueNicknameGeneratorTest {
 		// then
 		assertThat(uniqueNickname)
 			.isNotEqualTo(baseNickname)
-			.startsWith(baseNickname);
-		assertThat(uniqueNickname.length()).isGreaterThan(baseNickname.length());
-		assertThat(uniqueNickname.length()).isEqualTo(baseNickname.length() + 5);
+			.startsWith(baseNickname)
+			.isGreaterThan(baseNickname)
+			.hasSize(baseNickname.length() + 5);
+
 		verify(memberRepository, times(10)).existsByNickname(anyString());
 
 		log.info("baseNickname = {}", baseNickname);
@@ -77,28 +77,99 @@ class UniqueNicknameGeneratorTest {
 	}
 
 	/**
-	 * <h2>[예외] 중복 닉네임 생성 실패 - 10회</h2>
-	 * <p>결과: 중복인 경우, BaseException 발생</p>
-	 * <p>검증 방식: 예외 발생 여부</p>
-	 * <p>- 최대 시도 횟수는 10회로 제한.</p>
+	 * <h2>[예외] 기본 닉네임이 없는 경우, 기본 닉네임으로 설정</h2>
+	 * <p>결과: 기본 닉네임이 없는 경우, 기본 닉네임으로 설정</p>
+	 * <p>검증 방식: 동등성 확인</p>
 	 */
 	@Test
-	@DisplayName("[예외] 중복 닉네임인 경우, 중복되지 않는 닉네임 생성 실패 - generateUniqueNickname")
-	void generateUniqueNicknameDuplicateFail() {
+	@DisplayName("[예외] 기본 닉네임이 없는 경우, 기본 닉네임으로 설정 - generateUniqueNickname")
+	void generateUniqueNicknameWithNullBaseNickname() {
 
 		// given
-		String baseNickname = "은하";
-		when(memberRepository.existsByNickname(any())).thenReturn(true, true, true, true, true,
-			true, true, true, true, true);
+		String baseNickname = null;
+		when(memberRepository.existsByNickname(any())).thenReturn(false);
 
-		// when, then
-		String uniqueNickname = baseNickname;
-		assertThatThrownBy(() -> {
-			UniqueNicknameGenerator.generateUniqueNickname(uniqueNickname,
-				nickname -> memberRepository.existsByNickname(nickname)
-			);
-		}).isInstanceOf(BaseException.class)
-			.hasMessageContaining("최대 시도 횟수를 초과했습니다.");
+		// when
+		String uniqueNickname = UniqueNicknameGenerator.generateUniqueNickname(baseNickname,
+			nickname -> memberRepository.existsByNickname(nickname)
+		);
+		// then
+		assertThat(uniqueNickname).isEqualTo("은하");
+	}
+
+	/**
+	 * <h2>[예외] 처음부터 15자인 경우, 중복이 아니면 그대로 반환</h2>
+	 * <p>결과: 처음부터 15자인 경우, 중복이 아니면 그대로 반환</p>
+	 * <p>검증 방식: 동등성 확인 및 호출 횟수</p>
+	 */
+	@Test
+	@DisplayName("[예외] 처음 닉네임부터 15자인 경우, 중복이 아니면 그대로 반환 - generateUniqueNickname")
+	void generateUniqueNicknameWithMaxLength() {
+
+		// given
+		String korBaseNickname = "일이삼사오육칠팔구십일이삼사오";
+		when(memberRepository.existsByNickname(korBaseNickname)).thenReturn(false);
+
+		// when
+		String uniqueNicknameKor = UniqueNicknameGenerator.generateUniqueNickname(korBaseNickname,
+			nickname -> memberRepository.existsByNickname(nickname));
+
+		// then
+		assertThat(uniqueNicknameKor).isEqualTo(korBaseNickname);
+		verify(memberRepository, times(1) ).existsByNickname(korBaseNickname);
+
+	}
+
+	/**
+	 * <h2>[예외] 10이상 15자 미만인 경우, 15자에서 남은 수만큼 랜덤으로 생성</h2>
+	 * <p>결과: 10이상 15자 미만인 경우, 15자에서 남은 수만큼 랜덤으로 생성</p>
+	 * <p>검증 방식: 길이, 포함하는 문자, 중복만큼 호출됐는지 확인</p>
+	 */
+	@Test
+	@DisplayName("[예외] 10이상 15자 미만인 경우, 15자에서 남은 수만큼 랜덤으로 생성 - generateUniqueNickname")
+	void generateUniqueNicknameWithOverMaxLengthAndDuplicate() {
+
+		// given
+		String korBaseNickname = "일이삼사오육칠팔구십일이삼사";
+		when(memberRepository.existsByNickname(any())).thenReturn(true, false);
+
+		// when
+		String uniqueNicknameKor = UniqueNicknameGenerator.generateUniqueNickname(korBaseNickname,
+			nickname -> memberRepository.existsByNickname(nickname));
+
+		// then
+		assertThat(uniqueNicknameKor)
+			.isNotEqualTo(korBaseNickname)
+			.startsWith("일이삼사오육칠팔구십일이삼사")
+			.hasSize(15);
+		verify(memberRepository, times(2)).existsByNickname(anyString());
+
+	}
+
+	/**
+	 * <h2>[예외] 처음부터 15자, 중복인 경우</h2>
+	 * <p>결과: 10글자만 남기고, 뒤는 랜덤으로 생성</p>
+	 * <p>검증 방식: 길이, 포함하는 문자, 중복만큼 호출됐는지 확인</p>
+	 */
+	@Test
+	@DisplayName("[예외] 처음부터 15자, 10글자만 보존, 15자로 생성- generateUniqueNickname")
+	void generateUniqueNicknameWithMaxLengthAndDuplicate() {
+
+		// given
+		String korBaseNickname = "일이삼사오육칠팔구십일이삼사오";
+		when(memberRepository.existsByNickname(anyString())).thenReturn(true, true, false);
+
+		// when
+		String uniqueNicknameKor = UniqueNicknameGenerator.generateUniqueNickname(korBaseNickname,
+			nickname -> memberRepository.existsByNickname(nickname));
+
+		// then
+		assertThat(uniqueNicknameKor)
+			.isNotEqualTo(korBaseNickname)
+			.startsWith("일이삼사오육칠팔구십")
+			.doesNotContain("일이삼사오육칠팔구십일")
+			.hasSize(15);
+		verify(memberRepository, times(3)).existsByNickname(anyString());
 
 	}
 


### PR DESCRIPTION
## 변경 내용 
- 닉네임 변경 15자 제한 추가
  - 닉네임 처음 생성 시에는 임의로 랜덤 문자 넣어줌 (소셜 로그인에서 닉네임이 없는 경우가 있기 때문)
    - 15자 이상이면 10자까지만 보존, 이후는 랜덤 UUID 문자
    - 15자 미만이면 최대 5문자 랜덤 UUID
  - 수정 시에는 400 응답

## 특이 사항
- .

## 체크리스트

- [X] PR 날리기 전에 main branch pull 받으셨나요?
- [X] application.properties 등 노출되지 않아야 하는 파일이 올라가지는 않았나요?
- [X] 다른 담당자 파일을 수정한 부분에 대해서 이야기 하셨나요?
- [X] 주석 "상세히" 다셨나요?
- [X] 제출하기 전에 테스트코드 돌려 보셨나요?

closes #294 
