### PR TITLE
[#312] fix: PathVariable이 잘못되었을때 서버에러로 인식되는 버그 수정

### DIFF
--- a/src/main/java/goorm/eagle7/stelligence/api/GlobalRestControllerAdvice.java
+++ b/src/main/java/goorm/eagle7/stelligence/api/GlobalRestControllerAdvice.java
@@ -8,8 +8,10 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 import goorm.eagle7.stelligence.api.exception.BaseException;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -34,6 +36,12 @@ public class GlobalRestControllerAdvice {
 	public ResponseTemplate<String> handleBaseException(BaseException ex) {
 		log.debug("Exception catched in RestControllerAdvice : {}", ex.getMessage());
 		return ResponseTemplate.fail(ex.getMessage());
+	}
+
+	@ResponseStatus(HttpStatus.BAD_REQUEST)
+	@ExceptionHandler(MethodArgumentTypeMismatchException.class)
+	public ResponseTemplate<String> handleMethodArgumentTypeMismatchException(HttpServletRequest request) {
+		return ResponseTemplate.fail("잘못된 URI입니다. request URI: \"" + request.getRequestURI() + "\"");
 	}
 
 	@ResponseStatus(HttpStatus.BAD_REQUEST)


### PR DESCRIPTION
## 변경 내용 

- PathVariable이 잘못되었을때 서버에러로 인식되는 버그를 수정하였습니다.
- GlobalRestControllerAdvice에 MethodArgumentTypeMismatchException를 처리하는 ExceptionHandler를 추가하였습니다.

## 특이 사항

- 

## 체크리스트

- [x] PR 날리기 전에 main branch pull 받으셨나요?
- [x] application.properties 등 노출되지 않아야 하는 파일이 올라가지는 않았나요?
- [x] 다른 담당자 파일을 수정한 부분에 대해서 이야기 하셨나요?
- [x] 주석 "상세히" 다셨나요?
- [x] 제출하기 전에 테스트코드 돌려 보셨나요?

closes #
