### PR TITLE
318 amendment html sanitize

### DIFF
--- a/src/main/java/goorm/eagle7/stelligence/domain/amendment/AmendmentService.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/amendment/AmendmentService.java
@@ -1,5 +1,6 @@
 package goorm.eagle7.stelligence.domain.amendment;
 
+import org.owasp.html.PolicyFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,6 +19,7 @@ import lombok.extern.slf4j.Slf4j;
 public class AmendmentService {
 
 	private final SectionRepository sectionRepository;
+	private final PolicyFactory policyFactory;
 
 	/**
 	 * 타입 구분
@@ -42,7 +44,7 @@ public class AmendmentService {
 			section,
 			amendmentRequest.getNewSectionHeading(),
 			amendmentRequest.getNewSectionTitle(),
-			amendmentRequest.getNewSectionContent(),
+			policyFactory.sanitize(amendmentRequest.getNewSectionContent()),
 			amendmentRequest.getCreatingOrder()
 		);
 	}
@@ -58,7 +60,7 @@ public class AmendmentService {
 			section,
 			amendmentRequest.getNewSectionHeading(),
 			amendmentRequest.getNewSectionTitle(),
-			amendmentRequest.getNewSectionContent()
+			policyFactory.sanitize(amendmentRequest.getNewSectionContent())
 		);
 	}
 

--- a/src/main/java/goorm/eagle7/stelligence/domain/document/content/DocumentContentService.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/document/content/DocumentContentService.java
@@ -2,6 +2,7 @@ package goorm.eagle7.stelligence.domain.document.content;
 
 import java.util.List;
 
+import org.owasp.html.PolicyFactory;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -35,6 +36,7 @@ public class DocumentContentService {
 	private final SectionRepository sectionRepository;
 	private final SectionIdGenerator sectionIdGenerator;
 	private final DocumentParser documentParser;
+	private final PolicyFactory policyFactory;
 
 	/**
 	 * Document를 생성합니다.
@@ -56,7 +58,10 @@ public class DocumentContentService {
 		Document document = Document.createDocument(title, author, parentDocument);
 		documentRepository.save(document);
 
-		List<SectionRequest> sectionRequests = documentParser.parse(rawContent);
+		// 악성 스크립트를 방지하기 위해 HTML를 필터링합니다.
+		String sanitizedContent = policyFactory.sanitize(rawContent);
+
+		List<SectionRequest> sectionRequests = documentParser.parse(sanitizedContent);
 
 		//section 생성
 		for (int order = 0; order < sectionRequests.size(); order++) {

--- a/src/main/java/goorm/eagle7/stelligence/domain/document/content/parser/TagDocumentParser.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/document/content/parser/TagDocumentParser.java
@@ -5,7 +5,6 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.owasp.html.PolicyFactory;
 import org.springframework.stereotype.Component;
 
 import goorm.eagle7.stelligence.api.exception.BaseException;
@@ -22,24 +21,20 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class TagDocumentParser implements DocumentParser {
 
-	private final PolicyFactory policyFactory;
-
 	// Heading 태그를 기반으로 문서를 파싱하기 위한 정규식
 	private static final Pattern HEADING_TAG_PATTERN = Pattern.compile(
 		"(<h([1-6])>(.*?)</h\\2>)(.*?)(?=<h[1-6]>|$)", Pattern.DOTALL);
 
 	/**
 	 * HTML 태그로 들어온 문서를 파싱하여 SectionRequest로 변환합니다.
-	 * @param rawContent HTML 태그로 들어온 문서
+	 * @param htmlContent HTML 태그로 들어온 문서
 	 * @return SectionRequest 리스트
 	 */
 	@Override
-	public List<SectionRequest> parse(String rawContent) {
-		// 악성 스크립트를 방지하기 위해 HTML를 필터링합니다.
-		String sanitizedContent = policyFactory.sanitize(rawContent);
+	public List<SectionRequest> parse(String htmlContent) {
 
 		List<SectionRequest> sectionRequests = new ArrayList<>();
-		Matcher matcher = HEADING_TAG_PATTERN.matcher(sanitizedContent);
+		Matcher matcher = HEADING_TAG_PATTERN.matcher(htmlContent);
 
 		while (matcher.find()) {
 			String level = getValidLevel(matcher.group(2));

--- a/src/test/java/goorm/eagle7/stelligence/config/HtmlPolicyConfigTest.java
+++ b/src/test/java/goorm/eagle7/stelligence/config/HtmlPolicyConfigTest.java
@@ -37,4 +37,16 @@ class HtmlPolicyConfigTest {
 		assertThat(sanitizedContent).isEqualTo("<p>hello</p>");
 	}
 
+	@Test
+	void whenNullReturnEmptyString() {
+		//given
+		String rawContent = null;
+
+		//when
+		String sanitizedContent = policyFactory.sanitize(rawContent);
+
+		//then
+		assertThat(sanitizedContent).isEmpty();
+	}
+
 }

--- a/src/test/java/goorm/eagle7/stelligence/domain/document/content/DocumentContentServiceCreateUnitTest.java
+++ b/src/test/java/goorm/eagle7/stelligence/domain/document/content/DocumentContentServiceCreateUnitTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.owasp.html.PolicyFactory;
 
 import goorm.eagle7.stelligence.common.sequence.SectionIdGenerator;
 import goorm.eagle7.stelligence.config.MockSectionIdGenerator;
@@ -42,6 +43,9 @@ class DocumentContentServiceCreateUnitTest {
 	@Mock
 	DocumentParser documentParser;
 
+	@Mock
+	PolicyFactory policyFactory;
+
 	@InjectMocks
 	DocumentContentService documentContentService;
 
@@ -60,10 +64,9 @@ class DocumentContentServiceCreateUnitTest {
 		sectionRequests.add(new SectionRequest(Heading.H1, "title1", "testRawContent\n"));
 		sectionRequests.add(new SectionRequest(Heading.H2, "title2", "content2 line 1\ncontent2 line 2\n"));
 
-		//문서 파싱 결과를 반환하도록 설정
-		when(documentParser.parse(rawContent)).thenReturn(sectionRequests);
-
 		//when
+		when(policyFactory.sanitize(rawContent)).thenReturn(rawContent);
+		when(documentParser.parse(rawContent)).thenReturn(sectionRequests);
 		Document document = documentContentService.createDocument(title, rawContent, null, author);
 
 		//then
@@ -105,6 +108,7 @@ class DocumentContentServiceCreateUnitTest {
 		sectionRequests.add(new SectionRequest(Heading.H2, "title2", "content2 line 1\ncontent2 line 2\n"));
 
 		//when
+		when(policyFactory.sanitize(rawContent)).thenReturn(rawContent);
 		when(documentParser.parse(rawContent)).thenReturn(sectionRequests);
 		when(documentContentRepository.findById(2L)).thenReturn(
 			Optional.of(parent));

--- a/src/test/java/goorm/eagle7/stelligence/domain/document/content/parser/TagDocumentParserTest.java
+++ b/src/test/java/goorm/eagle7/stelligence/domain/document/content/parser/TagDocumentParserTest.java
@@ -1,7 +1,6 @@
 package goorm.eagle7.stelligence.domain.document.content.parser;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.mockito.Mockito.*;
 
 import java.util.List;
 
@@ -9,18 +8,13 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.owasp.html.PolicyFactory;
 
 import goorm.eagle7.stelligence.domain.document.content.dto.SectionRequest;
 import goorm.eagle7.stelligence.domain.section.model.Heading;
 
 @ExtendWith(MockitoExtension.class)
 class TagDocumentParserTest {
-
-	@Mock
-	PolicyFactory policyFactory;
 
 	@InjectMocks
 	TagDocumentParser tagDocumentParser;
@@ -39,7 +33,6 @@ class TagDocumentParserTest {
 				+ "<p>content3</p>";
 
 		//when
-		when(policyFactory.sanitize(rawContent)).thenReturn(rawContent);
 		List<SectionRequest> result = tagDocumentParser.parse(rawContent);
 
 		//then
@@ -72,7 +65,6 @@ class TagDocumentParserTest {
 				+ "<p>content3</p>";
 
 		//when
-		when(policyFactory.sanitize(rawContent)).thenReturn(rawContent);
 		List<SectionRequest> result = tagDocumentParser.parse(rawContent);
 
 		//then
@@ -100,7 +92,6 @@ class TagDocumentParserTest {
 				+ "<p>content3</p>";
 
 		//when
-		when(policyFactory.sanitize(rawContent)).thenReturn(rawContent);
 		List<SectionRequest> result = tagDocumentParser.parse(rawContent);
 
 		//then
@@ -131,7 +122,6 @@ class TagDocumentParserTest {
 				+ "<h6>h6</h6>";
 
 		//when
-		when(policyFactory.sanitize(rawContent)).thenReturn(rawContent);
 		List<SectionRequest> result = tagDocumentParser.parse(rawContent);
 
 		//then


### PR DESCRIPTION
## 변경 내용 

- 이제는 수정요청으로 들어오는 html 문자열도 sanitize의 대상이 됩니다.
- 기존에 DocumentParser에서 수행되던 sanitize를 제거하였고, sanitize의 책임을 documentContentService와 amendmentService에 부여하였습니다.

## 특이 사항

- 

## 체크리스트

- [x] PR 날리기 전에 main branch pull 받으셨나요?
- [x] application.properties 등 노출되지 않아야 하는 파일이 올라가지는 않았나요?
- [x] 다른 담당자 파일을 수정한 부분에 대해서 이야기 하셨나요?
- [x] 주석 "상세히" 다셨나요?
- [x] 제출하기 전에 테스트코드 돌려 보셨나요?

closes #318 
