### PR TITLE
[#322] fix: 제목으로 문서 검색시 대소문자 구분 안하도록 수정

### DIFF
--- a/src/main/java/goorm/eagle7/stelligence/domain/document/graph/DocumentNodeRepository.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/document/graph/DocumentNodeRepository.java
@@ -41,7 +41,7 @@ public interface DocumentNodeRepository extends Neo4jRepository<DocumentNode, Lo
 	// 	+ " where score > 0"
 	// 	+ " return node.documentId as documentId, node.title as title, node.group as group")
 	@Query("match (n:DocumentNode)"
-		+ " where n.title contains $title"
+		+ " where toLower(n.title) contains toLower($title)"
 		+ " return n.documentId as documentId, n.title as title, n.group as group"
 		+ " limit $limit")
 	List<DocumentNodeResponse> findNodeByTitle(@Param("title") String title, @Param("limit") int limit);

--- a/src/test/java/goorm/eagle7/stelligence/domain/document/graph/DocumentNodeRepositoryTest.java
+++ b/src/test/java/goorm/eagle7/stelligence/domain/document/graph/DocumentNodeRepositoryTest.java
@@ -184,6 +184,31 @@ class DocumentNodeRepositoryTest {
 	}
 
 	@Test
+	@DisplayName("대소문자에 구분없이 검색이 잘 이루어짐")
+	void findNodeByUppercaseTitle() {
+
+		//given
+		final String searchTitle = "TitLe1";
+		final int limit = 5;
+
+		String[] queries = queriesThatMakesThreeNodesWithDepthFour();
+
+		for (String queryString : queries) {
+			neo4jClient.query(queryString).run();
+		}
+
+		//when
+		List<DocumentNodeResponse> findNodes = documentNodeRepository.findNodeByTitle(searchTitle, limit);
+
+		//then
+		log.info("findNodes: {}", findNodes);
+		List<String> titleList = findNodes.stream().map(DocumentNodeResponse::getTitle).toList();
+		assertThat(titleList)
+			.isNotEmpty()
+			.allMatch(s -> s.toLowerCase().contains(searchTitle.toLowerCase()));
+	}
+
+	@Test
 	@DisplayName("존재하지 않는 제목으로 검색하면 결과가 빈 리스트로 반환")
 	void findNoNodeByTitle() {
 


### PR DESCRIPTION
## 변경 내용 

- 제목으로 검색시에 spring을 검색하면 Spring이 나오지 않는 식으로 대소문자가 구분되는 문제가 있었습니다.
- 이제는 대소문자 구분 안하고 검색을 수행할 수 있습니다.

## 특이 사항

- 

## 체크리스트

- [x] PR 날리기 전에 main branch pull 받으셨나요?
- [x] application.properties 등 노출되지 않아야 하는 파일이 올라가지는 않았나요?
- [x] 다른 담당자 파일을 수정한 부분에 대해서 이야기 하셨나요?
- [x] 주석 "상세히" 다셨나요?
- [x] 제출하기 전에 테스트코드 돌려 보셨나요?

closes #
