### PR TITLE
328 언급링크를 위한 제목검색 완전일치 api 추가

### DIFF
--- a/src/main/java/goorm/eagle7/stelligence/domain/document/DocumentController.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/document/DocumentController.java
@@ -15,6 +15,7 @@ import goorm.eagle7.stelligence.api.ResponseTemplate;
 import goorm.eagle7.stelligence.common.auth.memberinfo.Auth;
 import goorm.eagle7.stelligence.common.auth.memberinfo.MemberInfo;
 import goorm.eagle7.stelligence.domain.document.content.dto.DocumentResponse;
+import goorm.eagle7.stelligence.domain.document.content.dto.DocumentSimpleResponse;
 import goorm.eagle7.stelligence.domain.document.content.dto.DocumentStatusResponse;
 import goorm.eagle7.stelligence.domain.document.dto.DocumentCreateRequest;
 import goorm.eagle7.stelligence.domain.document.graph.dto.DocumentGraphResponse;
@@ -114,5 +115,19 @@ public class DocumentController {
 	) {
 
 		return ResponseTemplate.ok(documentService.getDocumentNodeByTitle(title, limit));
+	}
+
+	@Operation(summary = "제목과 일치하는 문서 조회", description = "특정 제목과 일치하는 문서를 조회합니다.")
+	@ApiResponse(
+		responseCode = "200",
+		description = "제목과 일치하는 문서 조회 성공",
+		useReturnTypeSchema = true
+	)
+	@GetMapping("/exact-search")
+	public ResponseTemplate<DocumentSimpleResponse> searchExactDocument(
+		@Parameter(description = "검색할 제목", example = "제목")
+		@RequestParam("title") String title
+	) {
+		return ResponseTemplate.ok(documentService.searchDocumentByExactTitle(title));
 	}
 }

--- a/src/main/java/goorm/eagle7/stelligence/domain/document/DocumentService.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/document/DocumentService.java
@@ -10,6 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 import goorm.eagle7.stelligence.api.exception.BaseException;
 import goorm.eagle7.stelligence.domain.document.content.DocumentContentService;
 import goorm.eagle7.stelligence.domain.document.content.dto.DocumentResponse;
+import goorm.eagle7.stelligence.domain.document.content.dto.DocumentSimpleResponse;
 import goorm.eagle7.stelligence.domain.document.content.dto.SectionResponse;
 import goorm.eagle7.stelligence.domain.document.content.model.Document;
 import goorm.eagle7.stelligence.domain.document.dto.DocumentCreateRequest;
@@ -154,5 +155,14 @@ public class DocumentService {
 	public void changeParentDocument(Long documentId, Long newParentDocumentId) {
 		documentContentService.updateParentDocument(documentId, newParentDocumentId);
 		documentGraphService.updateDocumentLink(documentId, newParentDocumentId);
+	}
+
+	/**
+	 * 입력받은 문자열과 일치하는 제목을 가진 문서를 검색합니다.
+	 * @param title 검색할 제목
+	 * @return DocumentSimpleResponse 검색한 문서의 ID와 제목
+	 */
+	public DocumentSimpleResponse searchDocumentByExactTitle(String title) {
+		return documentContentService.getDocumentByTitle(title);
 	}
 }

--- a/src/main/java/goorm/eagle7/stelligence/domain/document/content/DocumentContentService.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/document/content/DocumentContentService.java
@@ -9,6 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 import goorm.eagle7.stelligence.api.exception.BaseException;
 import goorm.eagle7.stelligence.common.sequence.SectionIdGenerator;
 import goorm.eagle7.stelligence.domain.document.content.dto.DocumentResponse;
+import goorm.eagle7.stelligence.domain.document.content.dto.DocumentSimpleResponse;
 import goorm.eagle7.stelligence.domain.document.content.dto.SectionRequest;
 import goorm.eagle7.stelligence.domain.document.content.dto.SectionResponse;
 import goorm.eagle7.stelligence.domain.document.content.model.Document;
@@ -156,5 +157,18 @@ public class DocumentContentService {
 			.orElseThrow(() -> new BaseException("상위 문서가 존재하지 않습니다. 문서 ID : " + newParentDocumentId));
 
 		document.updateParentDocument(parentDocument);
+	}
+
+	/**
+	 * 특정 제목으로 문서를 검색합니다.
+	 * @param title 검색할 제목
+	 * @return DocumentSimpleResponse
+	 */
+	public DocumentSimpleResponse getDocumentByTitle(String title) {
+
+		Document document = documentRepository.findByTitle(title)
+			.orElseThrow(() -> new BaseException("해당 제목을 갖는 문서가 존재하지 않습니다. 제목: " + title));
+
+		return DocumentSimpleResponse.from(document);
 	}
 }

--- a/src/main/java/goorm/eagle7/stelligence/domain/document/content/dto/DocumentSimpleResponse.java
+++ b/src/main/java/goorm/eagle7/stelligence/domain/document/content/dto/DocumentSimpleResponse.java
@@ -1,0 +1,20 @@
+package goorm.eagle7.stelligence.domain.document.content.dto;
+
+import goorm.eagle7.stelligence.domain.document.content.model.Document;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class DocumentSimpleResponse {
+
+	private Long documentId;
+	private String title;
+
+	public static DocumentSimpleResponse from(Document document) {
+		return new DocumentSimpleResponse(document.getId(), document.getTitle());
+	}
+}

--- a/src/test/java/goorm/eagle7/stelligence/domain/document/content/DocumentContentServiceReadUnitTest.java
+++ b/src/test/java/goorm/eagle7/stelligence/domain/document/content/DocumentContentServiceReadUnitTest.java
@@ -189,7 +189,6 @@ class DocumentContentServiceReadUnitTest {
 		DocumentSimpleResponse documentSimpleResponse = documentContentService.getDocumentByTitle(searchTitle);
 
 		//then
-		verify(documentContentRepository, times(1)).findByTitle(searchTitle);
 		assertThat(documentSimpleResponse.getTitle()).isEqualTo(searchTitle);
 		assertThat(documentSimpleResponse.getDocumentId()).isEqualTo(1L);
 	}

--- a/src/test/java/goorm/eagle7/stelligence/domain/document/content/DocumentContentServiceReadUnitTest.java
+++ b/src/test/java/goorm/eagle7/stelligence/domain/document/content/DocumentContentServiceReadUnitTest.java
@@ -18,6 +18,7 @@ import goorm.eagle7.stelligence.api.exception.BaseException;
 import goorm.eagle7.stelligence.domain.contribute.ContributeRepository;
 import goorm.eagle7.stelligence.domain.debate.repository.DebateRepository;
 import goorm.eagle7.stelligence.domain.document.content.dto.DocumentResponse;
+import goorm.eagle7.stelligence.domain.document.content.dto.DocumentSimpleResponse;
 import goorm.eagle7.stelligence.domain.document.content.model.Document;
 import goorm.eagle7.stelligence.domain.section.SectionRepository;
 import goorm.eagle7.stelligence.domain.section.model.Heading;
@@ -173,5 +174,38 @@ class DocumentContentServiceReadUnitTest {
 		//then
 		assertThat(documentResponse.getParentDocumentId()).isEqualTo(2L);
 		assertThat(documentResponse.getParentDocumentTitle()).isEqualTo("parentTitle");
+	}
+
+	@Test
+	@DisplayName("문서 제목으로 검색 - 존재하는 제목")
+	void getExistDocumentByTitle() {
+		//given
+		final String searchTitle = "title1";
+		Document document = document(1L, member(1L, "hello"), searchTitle, 1L, null);
+
+		//when
+		when(documentContentRepository.findByTitle(searchTitle)).thenReturn(Optional.of(document));
+
+		DocumentSimpleResponse documentSimpleResponse = documentContentService.getDocumentByTitle(searchTitle);
+
+		//then
+		verify(documentContentRepository, times(1)).findByTitle(searchTitle);
+		assertThat(documentSimpleResponse.getTitle()).isEqualTo(searchTitle);
+		assertThat(documentSimpleResponse.getDocumentId()).isEqualTo(1L);
+	}
+
+	@Test
+	@DisplayName("문서 제목으로 검색 - 존재하지 않는 제목")
+	void getNonExistDocumentByTitle() {
+		//given
+		final String searchTitle = "nonExistTitle";
+
+		//when
+		when(documentContentRepository.findByTitle(searchTitle)).thenReturn(Optional.empty());
+
+		//then
+		assertThatThrownBy(() -> documentContentService.getDocumentByTitle(searchTitle))
+			.isInstanceOf(BaseException.class)
+			.hasMessage("해당 제목을 갖는 문서가 존재하지 않습니다. 제목: " + searchTitle);
 	}
 }


### PR DESCRIPTION
## 변경 내용 

- 기존에는 제목 검색이 해당 문자열을 포함하는 문서를 검색하는 방식이었습니다.
- 언급링크를 위해 정확히 입력한 제목과 일치하는 문서를 검색하는 API를 추가하였습니다.

## 특이 사항

- X

## 체크리스트

- [x] PR 날리기 전에 main branch pull 받으셨나요?
- [x] application.properties 등 노출되지 않아야 하는 파일이 올라가지는 않았나요?
- [x] 다른 담당자 파일을 수정한 부분에 대해서 이야기 하셨나요?
- [x] 주석 "상세히" 다셨나요?
- [x] 제출하기 전에 테스트코드 돌려 보셨나요?

closes #
