### PR TITLE
326 badge service test 작성

### DIFF
--- a/src/test/java/goorm/eagle7/stelligence/domain/badge/BadgeServiceTest.java
+++ b/src/test/java/goorm/eagle7/stelligence/domain/badge/BadgeServiceTest.java
@@ -6,7 +6,6 @@ import static org.mockito.Mockito.*;
 
 import java.util.Optional;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -15,6 +14,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
 
+import goorm.eagle7.stelligence.domain.badge.event.NewBadgeEvent;
 import goorm.eagle7.stelligence.domain.badge.model.Badge;
 import goorm.eagle7.stelligence.domain.badge.model.BadgeCategory;
 import goorm.eagle7.stelligence.domain.badge.template.BadgeMatchedCountTemplate;
@@ -34,7 +34,7 @@ class BadgeServiceTest {
 
 
 	@Test
-	@DisplayName("[성공] - 배지 추가, 글 작성 - WRITING, 1")
+	@DisplayName("[성공] - 배지 추가, 글 작성 - DOCUMENT - checkAndAwardBadge")
 	void getBadgeWriting1Success() {
 
 		// given
@@ -50,148 +50,56 @@ class BadgeServiceTest {
 		// when
 		badgeService.checkAndAwardBadge(BadgeCategory.DOCUMENT, member);
 
-		// then
+		// then - member에게 배지가 추가되고, 이벤트가 발행되었는지 확인
 		assertThat(member.getBadges())
 			.isNotEmpty()
 			.contains(Badge.ASTRONAUT)
-			.hasSize(1);
+			.hasSize(1); // TODO 왜 member는 mock 안 해도 되는 걸까?
+		verify(eventPublisher, times(1)).publishEvent(any(NewBadgeEvent.class));
 
 	}
-	//
-	// @Test
-	// @DisplayName("[예외] - 배지 추가, 글 작성 X (repository에 저장되지 않은 상황 가정) - WRITING, 0")
-	// void getBadgeWriting0() {
-	//
-	// 	// given
-	// 	BadgeCategory badgeCategory = BadgeCategory.DOCUMENT;
-	// 	when(documentContentRepository.countByAuthor_Id(member.getId())).thenReturn(0L);
-	//
-	// 	// when
-	// 	badgeService.checkAndAwardBadge(badgeCategory, member);
-	//
-	// 	// then
-	// 	assertThat(member.getBadges()).isEmpty();
-	// 	verify(documentContentRepository, times(1)).countByAuthor_Id(member.getId());
-	// 	verify(contributeRepository, never()).countByMemberId(member.getId());
-	// 	verify(contributeRepository, never()).countByMemberIdAndStatus(member.getId(), ContributeStatus.MERGED);
-	// 	verify(contributeRepository, never()).countByMemberIdAndStatus(member.getId(),
-	// 		ContributeStatus.REJECTED);
-	//
-	// }
-	//
-	// @Test
-	// @DisplayName("[성공] - 배지 추가, 모든 수정 요청 - CONTRIBUTE_ALL, 5")
-	// void getBadgeContributeAll5Success() {
-	//
-	// 	// given
-	// 	BadgeCategory badgeCategory = BadgeCategory.CONTRIBUTE_ALL;
-	// 	when(contributeRepository.countByMemberId(member.getId())).thenReturn(5L);
-	//
-	// 	// when
-	// 	badgeService.checkAndAwardBadge(badgeCategory, member);
-	//
-	// 	// then
-	// 	assertThat(member.getBadges())
-	// 		.isNotEmpty()
-	// 		.contains(Badge.VENUS)
-	// 		.hasSize(1);
-	// 	verify(contributeRepository, times(1)).countByMemberId(member.getId());
-	// 	verify(contributeRepository, never()).countByMemberIdAndStatus(member.getId(), ContributeStatus.MERGED);
-	// 	verify(contributeRepository, never()).countByMemberIdAndStatus(member.getId(),
-	// 		ContributeStatus.REJECTED);
-	// 	verify(documentContentRepository, never()).countByAuthor_Id(member.getId());
-	//
-	// }
-	//
-	// @Test
-	// @DisplayName("[예외] - 배지 추가, 모든 수정 요청 사잇값 - CONTRIBUTE_ALL, 8")
-	// void getBadgeContributeAll8() {
-	//
-	// 	// given
-	// 	BadgeCategory badgeCategory = BadgeCategory.CONTRIBUTE_ALL;
-	// 	when(contributeRepository.countByMemberId(member.getId())).thenReturn(8L);
-	//
-	// 	// when
-	// 	badgeService.checkAndAwardBadge(badgeCategory, member);
-	//
-	// 	// then
-	// 	assertThat(member.getBadges()).isEmpty();
-	// 	verify(contributeRepository, times(1)).countByMemberId(member.getId());
-	// 	verify(contributeRepository, never()).countByMemberIdAndStatus(member.getId(), ContributeStatus.MERGED);
-	// 	verify(contributeRepository, never()).countByMemberIdAndStatus(member.getId(),
-	// 		ContributeStatus.REJECTED);
-	// 	verify(documentContentRepository, never()).countByAuthor_Id(member.getId());
-	//
-	// }
-	//
-	// @Test
-	// @DisplayName("[성공] - 배지 추가, 반영된 수정 요청 - CONTRIBUTE_MERGED, 5")
-	// void getBadgeContributeMerged5Success() {
-	//
-	// 	// given
-	// 	BadgeCategory badgeCategory = BadgeCategory.CONTRIBUTE_MERGED;
-	// 	when(contributeRepository.countByMemberIdAndStatus(member.getId(), ContributeStatus.MERGED)).thenReturn(
-	// 		5L);
-	//
-	// 	// when
-	// 	badgeService.checkAndAwardBadge(badgeCategory, member);
-	//
-	// 	// then
-	// 	assertThat(member.getBadges())
-	// 		.isNotEmpty()
-	// 		.contains(Badge.SATURN)
-	// 		.hasSize(1);
-	// 	verify(contributeRepository, never()).countByMemberId(member.getId());
-	// 	verify(contributeRepository, times(1)).countByMemberIdAndStatus(member.getId(), ContributeStatus.MERGED);
-	// 	verify(contributeRepository, never()).countByMemberIdAndStatus(member.getId(),
-	// 		ContributeStatus.REJECTED);
-	// 	verify(documentContentRepository, never()).countByAuthor_Id(member.getId());
-	//
-	// }
-	//
-	// @Test
-	// @DisplayName("[성공] - 배지 추가, 반려된 수정 요청 - CONTRIBUTE_REJECTED, 100")
-	// void getBadgeContributeRejected100Success() {
-	//
-	// 	// given
-	// 	BadgeCategory badgeCategory = BadgeCategory.CONTRIBUTE_REJECTED;
-	// 	when(contributeRepository.countByMemberIdAndStatus(member.getId(),
-	// 		ContributeStatus.REJECTED)).thenReturn(100L);
-	//
-	// 	// when
-	// 	badgeService.checkAndAwardBadge(badgeCategory, member);
-	//
-	// 	// then
-	// 	assertThat(member.getBadges())
-	// 		.isNotEmpty()
-	// 		.contains(Badge.BLACKHOLE)
-	// 		.hasSize(1);
-	// 	verify(contributeRepository, never()).countByMemberId(member.getId());
-	// 	verify(contributeRepository, never()).countByMemberIdAndStatus(member.getId(), ContributeStatus.MERGED);
-	// 	verify(contributeRepository, times(1)).countByMemberIdAndStatus(member.getId(),
-	// 		ContributeStatus.REJECTED);
-	// 	verify(documentContentRepository, never()).countByAuthor_Id(member.getId());
-	//
-	// }
-	//
-	// @Test
-	// @DisplayName("[실패] - (현재 미구현) 배지 추가, 신고 - REPORT, 10")
-	// void getBadgeReport10Fail() {
-	//
-	// 	// given
-	// 	BadgeCategory badgeCategory = BadgeCategory.REPORT;
-	//
-	// 	// when
-	// 	badgeService.checkAndAwardBadge(badgeCategory, member);
-	//
-	// 	// then
-	// 	assertThat(member.getBadges()).isEmpty();
-	// 	verify(contributeRepository, never()).countByMemberId(member.getId());
-	// 	verify(contributeRepository, never()).countByMemberIdAndStatus(member.getId(), ContributeStatus.MERGED);
-	// 	verify(contributeRepository, never()).countByMemberIdAndStatus(member.getId(),
-	// 		ContributeStatus.REJECTED);
-	// 	verify(documentContentRepository, never()).countByAuthor_Id(member.getId());
-	//
-	// }
+
+
+	@Test
+	@DisplayName("[예외] - BadgeCategory에 해당하는 템플릿이 없을 경우, IllegalArgumentException - checkAndAwardBadge")
+	void getBadgeWriting1Fail() {
+
+		// given
+		// BadgeMatchedCountTemplate template = mock(BadgeMatchedCountTemplate.class);
+		Member member = member(1L, "nickname");
+		// badgeCategory에 해당하는 전략 category 찾기
+		when(badgeTemplateMatcher.findTemplate(BadgeCategory.CONTRIBUTE_MERGED)).thenReturn(null);
+
+		// when, then - 해당하는 badge category가 없을 경우, IllegalArgumentException
+		assertThatThrownBy(() ->
+			badgeService.checkAndAwardBadge(
+				BadgeCategory.CONTRIBUTE_MERGED,member))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("해당하는 badge category가 없습니다.: CONTRIBUTE_MERGED");
+		verify(eventPublisher, never()).publishEvent(any(NewBadgeEvent.class));
+
+	}
+
+
+	@Test
+	@DisplayName("[예외] - 현재 조건을 만족하는 배지가 없는 경우, empty - checkAndAwardBadge")
+	void getBadgeWriting0Fail() {
+
+		// given
+		Member member = member(1L, "nickname");
+		BadgeMatchedCountTemplate template = mock(BadgeMatchedCountTemplate.class);
+		// badgeCategory에 해당하는 전략 category 찾기
+		when(badgeTemplateMatcher.findTemplate(BadgeCategory.REPORT)).thenReturn(template);
+		// 배지 찾기
+		when(template.getBadgeWithCount(member)).thenReturn(Optional.empty());
+
+		// when
+		badgeService.checkAndAwardBadge(BadgeCategory.REPORT, member);
+
+		// then - member에게 배지가 추가되지 않았는지, eventPublisher 호출 X 확인
+		assertThat(member.getBadges()).isEmpty();
+		verify(eventPublisher, never()).publishEvent(any(NewBadgeEvent.class));
+
+	}
 
 }

--- a/src/test/java/goorm/eagle7/stelligence/domain/badge/BadgeServiceTest.java
+++ b/src/test/java/goorm/eagle7/stelligence/domain/badge/BadgeServiceTest.java
@@ -1,0 +1,197 @@
+package goorm.eagle7.stelligence.domain.badge;
+
+import static goorm.eagle7.stelligence.config.mockdata.TestFixtureGenerator.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+import goorm.eagle7.stelligence.domain.badge.model.Badge;
+import goorm.eagle7.stelligence.domain.badge.model.BadgeCategory;
+import goorm.eagle7.stelligence.domain.badge.template.BadgeMatchedCountTemplate;
+import goorm.eagle7.stelligence.domain.badge.template.BadgeTemplateMatcher;
+import goorm.eagle7.stelligence.domain.member.model.Member;
+
+@ExtendWith(MockitoExtension.class)
+class BadgeServiceTest {
+
+	@Mock
+	private BadgeTemplateMatcher badgeTemplateMatcher;
+	@Mock
+	private ApplicationEventPublisher eventPublisher;
+
+	@InjectMocks
+	private BadgeService badgeService;
+
+
+	@Test
+	@DisplayName("[성공] - 배지 추가, 글 작성 - WRITING, 1")
+	void getBadgeWriting1Success() {
+
+		// given
+		// DocumentBadgeMatchedCountTemplate template = new DocumentBadgeMatchedCountTemplate(
+		// 	documentContentRepository); // TODO 이건 왜 안 될까?
+		Member member = member(1L, "nickname");
+		BadgeMatchedCountTemplate template = mock(BadgeMatchedCountTemplate.class);
+		// badgeCategory에 해당하는 전략 category 찾기
+		when(badgeTemplateMatcher.findTemplate(BadgeCategory.DOCUMENT)).thenReturn(template);
+		// 배지 찾기
+		when(template.getBadgeWithCount(member)).thenReturn(Optional.of(Badge.ASTRONAUT));
+
+		// when
+		badgeService.checkAndAwardBadge(BadgeCategory.DOCUMENT, member);
+
+		// then
+		assertThat(member.getBadges())
+			.isNotEmpty()
+			.contains(Badge.ASTRONAUT)
+			.hasSize(1);
+
+	}
+	//
+	// @Test
+	// @DisplayName("[예외] - 배지 추가, 글 작성 X (repository에 저장되지 않은 상황 가정) - WRITING, 0")
+	// void getBadgeWriting0() {
+	//
+	// 	// given
+	// 	BadgeCategory badgeCategory = BadgeCategory.DOCUMENT;
+	// 	when(documentContentRepository.countByAuthor_Id(member.getId())).thenReturn(0L);
+	//
+	// 	// when
+	// 	badgeService.checkAndAwardBadge(badgeCategory, member);
+	//
+	// 	// then
+	// 	assertThat(member.getBadges()).isEmpty();
+	// 	verify(documentContentRepository, times(1)).countByAuthor_Id(member.getId());
+	// 	verify(contributeRepository, never()).countByMemberId(member.getId());
+	// 	verify(contributeRepository, never()).countByMemberIdAndStatus(member.getId(), ContributeStatus.MERGED);
+	// 	verify(contributeRepository, never()).countByMemberIdAndStatus(member.getId(),
+	// 		ContributeStatus.REJECTED);
+	//
+	// }
+	//
+	// @Test
+	// @DisplayName("[성공] - 배지 추가, 모든 수정 요청 - CONTRIBUTE_ALL, 5")
+	// void getBadgeContributeAll5Success() {
+	//
+	// 	// given
+	// 	BadgeCategory badgeCategory = BadgeCategory.CONTRIBUTE_ALL;
+	// 	when(contributeRepository.countByMemberId(member.getId())).thenReturn(5L);
+	//
+	// 	// when
+	// 	badgeService.checkAndAwardBadge(badgeCategory, member);
+	//
+	// 	// then
+	// 	assertThat(member.getBadges())
+	// 		.isNotEmpty()
+	// 		.contains(Badge.VENUS)
+	// 		.hasSize(1);
+	// 	verify(contributeRepository, times(1)).countByMemberId(member.getId());
+	// 	verify(contributeRepository, never()).countByMemberIdAndStatus(member.getId(), ContributeStatus.MERGED);
+	// 	verify(contributeRepository, never()).countByMemberIdAndStatus(member.getId(),
+	// 		ContributeStatus.REJECTED);
+	// 	verify(documentContentRepository, never()).countByAuthor_Id(member.getId());
+	//
+	// }
+	//
+	// @Test
+	// @DisplayName("[예외] - 배지 추가, 모든 수정 요청 사잇값 - CONTRIBUTE_ALL, 8")
+	// void getBadgeContributeAll8() {
+	//
+	// 	// given
+	// 	BadgeCategory badgeCategory = BadgeCategory.CONTRIBUTE_ALL;
+	// 	when(contributeRepository.countByMemberId(member.getId())).thenReturn(8L);
+	//
+	// 	// when
+	// 	badgeService.checkAndAwardBadge(badgeCategory, member);
+	//
+	// 	// then
+	// 	assertThat(member.getBadges()).isEmpty();
+	// 	verify(contributeRepository, times(1)).countByMemberId(member.getId());
+	// 	verify(contributeRepository, never()).countByMemberIdAndStatus(member.getId(), ContributeStatus.MERGED);
+	// 	verify(contributeRepository, never()).countByMemberIdAndStatus(member.getId(),
+	// 		ContributeStatus.REJECTED);
+	// 	verify(documentContentRepository, never()).countByAuthor_Id(member.getId());
+	//
+	// }
+	//
+	// @Test
+	// @DisplayName("[성공] - 배지 추가, 반영된 수정 요청 - CONTRIBUTE_MERGED, 5")
+	// void getBadgeContributeMerged5Success() {
+	//
+	// 	// given
+	// 	BadgeCategory badgeCategory = BadgeCategory.CONTRIBUTE_MERGED;
+	// 	when(contributeRepository.countByMemberIdAndStatus(member.getId(), ContributeStatus.MERGED)).thenReturn(
+	// 		5L);
+	//
+	// 	// when
+	// 	badgeService.checkAndAwardBadge(badgeCategory, member);
+	//
+	// 	// then
+	// 	assertThat(member.getBadges())
+	// 		.isNotEmpty()
+	// 		.contains(Badge.SATURN)
+	// 		.hasSize(1);
+	// 	verify(contributeRepository, never()).countByMemberId(member.getId());
+	// 	verify(contributeRepository, times(1)).countByMemberIdAndStatus(member.getId(), ContributeStatus.MERGED);
+	// 	verify(contributeRepository, never()).countByMemberIdAndStatus(member.getId(),
+	// 		ContributeStatus.REJECTED);
+	// 	verify(documentContentRepository, never()).countByAuthor_Id(member.getId());
+	//
+	// }
+	//
+	// @Test
+	// @DisplayName("[성공] - 배지 추가, 반려된 수정 요청 - CONTRIBUTE_REJECTED, 100")
+	// void getBadgeContributeRejected100Success() {
+	//
+	// 	// given
+	// 	BadgeCategory badgeCategory = BadgeCategory.CONTRIBUTE_REJECTED;
+	// 	when(contributeRepository.countByMemberIdAndStatus(member.getId(),
+	// 		ContributeStatus.REJECTED)).thenReturn(100L);
+	//
+	// 	// when
+	// 	badgeService.checkAndAwardBadge(badgeCategory, member);
+	//
+	// 	// then
+	// 	assertThat(member.getBadges())
+	// 		.isNotEmpty()
+	// 		.contains(Badge.BLACKHOLE)
+	// 		.hasSize(1);
+	// 	verify(contributeRepository, never()).countByMemberId(member.getId());
+	// 	verify(contributeRepository, never()).countByMemberIdAndStatus(member.getId(), ContributeStatus.MERGED);
+	// 	verify(contributeRepository, times(1)).countByMemberIdAndStatus(member.getId(),
+	// 		ContributeStatus.REJECTED);
+	// 	verify(documentContentRepository, never()).countByAuthor_Id(member.getId());
+	//
+	// }
+	//
+	// @Test
+	// @DisplayName("[실패] - (현재 미구현) 배지 추가, 신고 - REPORT, 10")
+	// void getBadgeReport10Fail() {
+	//
+	// 	// given
+	// 	BadgeCategory badgeCategory = BadgeCategory.REPORT;
+	//
+	// 	// when
+	// 	badgeService.checkAndAwardBadge(badgeCategory, member);
+	//
+	// 	// then
+	// 	assertThat(member.getBadges()).isEmpty();
+	// 	verify(contributeRepository, never()).countByMemberId(member.getId());
+	// 	verify(contributeRepository, never()).countByMemberIdAndStatus(member.getId(), ContributeStatus.MERGED);
+	// 	verify(contributeRepository, never()).countByMemberIdAndStatus(member.getId(),
+	// 		ContributeStatus.REJECTED);
+	// 	verify(documentContentRepository, never()).countByAuthor_Id(member.getId());
+	//
+	// }
+
+}


### PR DESCRIPTION
## 변경 내용 
- 발급 성공, 카테고리가 없는 경우, 만족하는 배지가 없는 경우로 나눠 테스트 작성.

## 특이 사항
- notificationTest가 뜬금없이.. 깨지고, 다시 하니 통과....! @sbslc2000 
- 그냥 제 컴퓨터 이상인가 싶어서 우선 에러났던 로그 첨부합니다,,
```
java.lang.AssertionError: 
Expected size: 3 but was: 10 in:
[goorm.eagle7.stelligence.domain.notification.model.Notification@70e7914e,
    goorm.eagle7.stelligence.domain.notification.model.Notification@66b00ffe,
    goorm.eagle7.stelligence.domain.notification.model.Notification@4d5fd888,
    goorm.eagle7.stelligence.domain.notification.model.Notification@20b8e765,
    goorm.eagle7.stelligence.domain.notification.model.Notification@d2fc6e1,
    goorm.eagle7.stelligence.domain.notification.model.Notification@4da61cd5,
    goorm.eagle7.stelligence.domain.notification.model.Notification@221cf6e2,
    goorm.eagle7.stelligence.domain.notification.model.Notification@67ced751,
    goorm.eagle7.stelligence.domain.notification.model.Notification@5e06dc9e,
    goorm.eagle7.stelligence.domain.notification.model.Notification@48b95d60]
	at goorm.eagle7.stelligence.domain.notification.NotificationRepositoryTest.bulkInsert(NotificationRepositoryTest.java:35)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
	at java.base/java.lang.reflect.Method.invoke(Method.java:578)
	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:728)
	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
	at org.junit.jupiter.engine.extension.TimeoutExtension.intercept(TimeoutExtension.java:156)
	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestableMethod(TimeoutExtension.java:147)
	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestMethod(TimeoutExtension.java:86)
	at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker$ReflectiveInterceptorCall.lambda$ofVoidMethod$0(InterceptingExecutableInvoker.java:103)
	at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.lambda$invoke$0(InterceptingExecutableInvoker.java:93)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$InterceptedInvocation.proceed(InvocationInterceptorChain.java:106)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.proceed(InvocationInterceptorChain.java:64)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.chainAndInvoke(InvocationInterceptorChain.java:45)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.invoke(InvocationInterceptorChain.java:37)
	at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.invoke(InterceptingExecutableInvoker.java:92)
	at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.invoke(InterceptingExecutableInvoker.java:86)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.lambda$invokeTestMethod$7(TestMethodTestDescriptor.java:218)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.invokeTestMethod(TestMethodTestDescriptor.java:214)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:139)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:69)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:151)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:155)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:155)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.submit(SameThreadHierarchicalTestExecutorService.java:35)
	at org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutor.execute(HierarchicalTestExecutor.java:57)
	at org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine.execute(HierarchicalTestEngine.java:54)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:107)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:88)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:54)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:67)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:52)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:114)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:86)
	at org.junit.platform.launcher.core.DefaultLauncherSession$DelegatingLauncher.execute(DefaultLauncherSession.java:86)
	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor$CollectAllTestClassesExecutor.processAllTestClasses(JUnitPlatformTestClassProcessor.java:119)
	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor$CollectAllTestClassesExecutor.access$000(JUnitPlatformTestClassProcessor.java:94)
	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor.stop(JUnitPlatformTestClassProcessor.java:89)
	at org.gradle.api.internal.tasks.testing.SuiteTestClassProcessor.stop(SuiteTestClassProcessor.java:62)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
	at java.base/java.lang.reflect.Method.invoke(Method.java:578)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:36)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
	at org.gradle.internal.dispatch.ContextClassLoaderDispatch.dispatch(ContextClassLoaderDispatch.java:33)
	at org.gradle.internal.dispatch.ProxyDispatchAdapter$DispatchingInvocationHandler.invoke(ProxyDispatchAdapter.java:94)
	at jdk.proxy2/jdk.proxy2.$Proxy5.stop(Unknown Source)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker$3.run(TestWorker.java:193)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.executeAndMaintainThreadName(TestWorker.java:129)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:100)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:60)
	at org.gradle.process.internal.worker.child.ActionExecutionWorker.execute(ActionExecutionWorker.java:56)
	at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:113)
	at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:65)
	at worker.org.gradle.process.internal.worker.GradleWorkerMain.run(GradleWorkerMain.java:69)
	at worker.org.gradle.process.internal.worker.GradleWorkerMain.main(GradleWorkerMain.java:74)
```

- 서비스는 로직이 간단, template, matcher 부분에서 각 경계값 등 확인 예정.
- TODO 주석 답 아시는 분..? mock... 어렵네요...static... mock...

## 체크리스트
- [X] PR 날리기 전에 main branch pull 받으셨나요?
- [X] application.properties 등 노출되지 않아야 하는 파일이 올라가지는 않았나요?
- [X] 다른 담당자 파일을 수정한 부분에 대해서 이야기 하셨나요?
- [X] 주석 "상세히" 다셨나요?
- [X] 제출하기 전에 테스트코드 돌려 보셨나요?

closes #326
