### PR TITLE
338 memberinfoarguresolver test 코드 작성

### DIFF
--- a/src/test/java/goorm/eagle7/stelligence/common/auth/memberinfo/MemberInfoArgumentResolverTest.java
+++ b/src/test/java/goorm/eagle7/stelligence/common/auth/memberinfo/MemberInfoArgumentResolverTest.java
@@ -1,0 +1,166 @@
+package goorm.eagle7.stelligence.common.auth.memberinfo;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+
+import goorm.eagle7.stelligence.domain.member.model.Role;
+
+@ExtendWith(MockitoExtension.class)
+class MemberInfoArgumentResolverTest {
+
+	@InjectMocks
+	private MemberInfoArgumentResolver resolver;
+
+	@Test
+	@DisplayName("[성공] securityContext의 정보를 @Auth에 저장 - resolveArgument")
+	void resolveArgumentSuccess() throws NoSuchMethodException {
+
+		// given
+		// security context 설정
+		User user = new User("1", "", Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER")));
+		Authentication authentication = new TestingAuthenticationToken(user, null);
+		SecurityContextHolder.getContext().setAuthentication(authentication);
+
+		MethodParameter parameter = new MethodParameter(
+			TestController.class.getMethod("methodWithAuthAnnotation", String.class), 0);
+
+		// when
+		MemberInfo result = (MemberInfo)resolver.resolveArgument(parameter, null, null, null);
+
+		// then
+		assertThat(result.getId()).isEqualTo(1);
+		assertThat(result.getRole()).isEqualTo(Role.USER);
+
+	}
+
+	@Test
+	@DisplayName("[실패] securityContext의 정보를 @Auth에 저장 실패 - resolveArgument")
+	void resolveArgumentFailure() throws NoSuchMethodException {
+
+		// given
+		// security context 설정
+		User user = new User("anonymousUser", "", Collections.emptyList());
+		Authentication authentication = new TestingAuthenticationToken(user, null);
+		SecurityContextHolder.getContext().setAuthentication(authentication);
+
+		MethodParameter parameter = new MethodParameter(
+			TestController.class.getMethod("methodWithAuthAnnotation", String.class), 0);
+
+		// when
+		MemberInfo memberInfo = (MemberInfo)resolver.resolveArgument(parameter, null, null, null);
+
+		// then
+		assertThat(memberInfo).isNull();
+
+	}
+
+	@Test
+	@DisplayName("[확인] authorities 여러 개인 경우 동작 확인 - resolveArgument")
+	void resolveArgumentWithMultipleAuthorities() throws NoSuchMethodException {
+
+		// given
+		// security context 설정
+		List<SimpleGrantedAuthority> authorities = List.of(
+			new SimpleGrantedAuthority("ROLE_MANAGER"),
+			new SimpleGrantedAuthority("ROLE_USER"),
+			new SimpleGrantedAuthority("ROLE_ADMIN")
+		);
+
+		User user = new User("1", "", authorities);
+		Authentication authentication = new TestingAuthenticationToken(user, null);
+		SecurityContextHolder.getContext().setAuthentication(authentication);
+
+		MethodParameter parameter = new MethodParameter(
+			TestController.class.getMethod("methodWithAuthAnnotation", String.class), 0);
+
+		// when
+		MemberInfo result = (MemberInfo)resolver.resolveArgument(parameter, null, null, null);
+
+		// then - findFirst라서 LIST 순서가 아닌 role 정의 시 순서
+		assertThat(result.getId()).isEqualTo(1);
+		assertThat(result.getRole())
+			.isEqualTo(Role.ADMIN);
+
+	}
+
+	@Test
+	@DisplayName("[확인] authorities 여러 개인 경우 동작 확인 - resolveArgument")
+	void resolveArgumentWithMultipleAuthorities2() throws NoSuchMethodException {
+
+		// given
+		// security context 설정
+		List<SimpleGrantedAuthority> authorities = List.of(
+			new SimpleGrantedAuthority("ROLE_ADMIN"),
+			new SimpleGrantedAuthority("ROLE_USER")
+		);
+
+		User user = new User("1", "", authorities);
+		Authentication authentication = new TestingAuthenticationToken(user, null);
+		SecurityContextHolder.getContext().setAuthentication(authentication);
+
+		MethodParameter parameter = new MethodParameter(
+			TestController.class.getMethod("methodWithAuthAnnotation", String.class), 0);
+
+		// when
+		MemberInfo result = (MemberInfo)resolver.resolveArgument(parameter, null, null, null);
+
+		// then - findFirst라서 LIST 순서가 아닌 role 정의 시 순서
+		assertThat(result.getId()).isEqualTo(1);
+		assertThat(result.getRole())
+			.isEqualTo(Role.ADMIN);
+
+	}
+
+	@Test
+	@DisplayName("[확인] 없는 Role인 경우 User 반환 - resolveArgument")
+	void resolveArgumentWithNoRole() throws NoSuchMethodException {
+
+		// given
+		// security context 설정
+		List<SimpleGrantedAuthority> authorities = List.of(
+			new SimpleGrantedAuthority("ROLE_AAA"),
+			new SimpleGrantedAuthority("ROLE_USER"),
+			new SimpleGrantedAuthority("ROLE_ADMIN"),
+			new SimpleGrantedAuthority("ROLE_MANAGER")
+		);
+
+		User user = new User("1", "", authorities);
+		Authentication authentication = new TestingAuthenticationToken(user, null);
+		SecurityContextHolder.getContext().setAuthentication(authentication);
+
+		MethodParameter parameter = new MethodParameter(
+			TestController.class.getMethod("methodWithAuthAnnotation", String.class), 0);
+
+		// when
+		MemberInfo result = (MemberInfo)resolver.resolveArgument(parameter, null, null, null);
+
+		// then
+		assertThat(result.getId()).isEqualTo(1);
+		assertThat(result.getRole())
+			.isEqualTo(Role.USER);
+
+	}
+
+	private class TestController {
+		public void methodWithAuthAnnotation(@Auth String memberId) {
+		}
+
+		public void methodWithoutAuthAnnotation(String memberId) {
+		}
+
+	}
+}

--- a/src/test/java/goorm/eagle7/stelligence/common/auth/memberinfo/MemberInfoArgumentResolverTest.java
+++ b/src/test/java/goorm/eagle7/stelligence/common/auth/memberinfo/MemberInfoArgumentResolverTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.core.MethodParameter;
 import org.springframework.security.authentication.TestingAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -35,11 +34,8 @@ class MemberInfoArgumentResolverTest {
 		Authentication authentication = new TestingAuthenticationToken(user, null);
 		SecurityContextHolder.getContext().setAuthentication(authentication);
 
-		MethodParameter parameter = new MethodParameter(
-			TestController.class.getMethod("methodWithAuthAnnotation", String.class), 0);
-
 		// when
-		MemberInfo result = (MemberInfo)resolver.resolveArgument(parameter, null, null, null);
+		MemberInfo result = (MemberInfo)resolver.resolveArgument(null, null, null, null);
 
 		// then
 		assertThat(result.getId()).isEqualTo(1);
@@ -57,16 +53,14 @@ class MemberInfoArgumentResolverTest {
 		Authentication authentication = new TestingAuthenticationToken(user, null);
 		SecurityContextHolder.getContext().setAuthentication(authentication);
 
-		MethodParameter parameter = new MethodParameter(
-			TestController.class.getMethod("methodWithAuthAnnotation", String.class), 0);
-
 		// when
-		MemberInfo memberInfo = (MemberInfo)resolver.resolveArgument(parameter, null, null, null);
+		MemberInfo memberInfo = (MemberInfo)resolver.resolveArgument(null, null, null, null);
 
 		// then
 		assertThat(memberInfo).isNull();
 
 	}
+
 	@Test
 	@DisplayName("[확인] authorities 여러 개, 없는 role(admin 앞)이 있는 경우 동작 확인 - resolveArgument")
 	void resolveArgumentWithMultipleAuthoritiesWithNoRole() throws NoSuchMethodException {
@@ -83,11 +77,8 @@ class MemberInfoArgumentResolverTest {
 		Authentication authentication = new TestingAuthenticationToken(user, null);
 		SecurityContextHolder.getContext().setAuthentication(authentication);
 
-		MethodParameter parameter = new MethodParameter(
-			TestController.class.getMethod("methodWithAuthAnnotation", String.class), 0);
-
 		// when
-		MemberInfo result = (MemberInfo)resolver.resolveArgument(parameter, null, null, null);
+		MemberInfo result = (MemberInfo)resolver.resolveArgument(null, null, null, null);
 
 		// then
 		// ADMIN 기준 없는 ROLE이 앞이라 USER가 FindFirst 반환값
@@ -117,11 +108,8 @@ class MemberInfoArgumentResolverTest {
 		Authentication authentication = new TestingAuthenticationToken(user, null);
 		SecurityContextHolder.getContext().setAuthentication(authentication);
 
-		MethodParameter parameter = new MethodParameter(
-			TestController.class.getMethod("methodWithAuthAnnotation", String.class), 0);
-
 		// when
-		MemberInfo result = (MemberInfo)resolver.resolveArgument(parameter, null, null, null);
+		MemberInfo result = (MemberInfo)resolver.resolveArgument(null, null, null, null);
 
 		// then
 		// ADMIN 기준 없는 ROLE이 나중이라 ADMIN이 FindFirst 반환값
@@ -146,11 +134,8 @@ class MemberInfoArgumentResolverTest {
 		Authentication authentication = new TestingAuthenticationToken(user, null);
 		SecurityContextHolder.getContext().setAuthentication(authentication);
 
-		MethodParameter parameter = new MethodParameter(
-			TestController.class.getMethod("methodWithAuthAnnotation", String.class), 0);
-
 		// when
-		MemberInfo result = (MemberInfo)resolver.resolveArgument(parameter, null, null, null);
+		MemberInfo result = (MemberInfo)resolver.resolveArgument(null, null, null, null);
 
 		// then - findFirst라서 LIST 순서가 아닌 role 정의 시 순서
 		assertThat(result.getId()).isEqualTo(1);
@@ -174,11 +159,8 @@ class MemberInfoArgumentResolverTest {
 		Authentication authentication = new TestingAuthenticationToken(user, null);
 		SecurityContextHolder.getContext().setAuthentication(authentication);
 
-		MethodParameter parameter = new MethodParameter(
-			TestController.class.getMethod("methodWithAuthAnnotation", String.class), 0);
-
 		// when
-		MemberInfo result = (MemberInfo)resolver.resolveArgument(parameter, null, null, null);
+		MemberInfo result = (MemberInfo)resolver.resolveArgument(null, null, null, null);
 
 		// then
 		assertThat(result.getId()).isEqualTo(1);
@@ -187,12 +169,4 @@ class MemberInfoArgumentResolverTest {
 
 	}
 
-	private class TestController {
-		public void methodWithAuthAnnotation(@Auth String memberId) {
-		}
-
-		public void methodWithoutAuthAnnotation(String memberId) {
-		}
-
-	}
 }


### PR DESCRIPTION
## 변경 내용 
- 기본적으로 로그인했을 때, 안 했을 때의 상황 test
- role에 존재하지 않는 경우 test
- supports는 파라미터 이해 불가로 우선 테스트 제외

## 특이 사항
- 여러 권한인 경우 추가 테스트 진행
- role의 순서가 아닌 set의 순서로 findFirst 진행한다는 사실을 알아냄.. -> 여러 권한을 확인할 때는, 고려 필요 

## 체크리스트
- [X] PR 날리기 전에 main branch pull 받으셨나요?
- [X] application.properties 등 노출되지 않아야 하는 파일이 올라가지는 않았나요?
- [X] 다른 담당자 파일을 수정한 부분에 대해서 이야기 하셨나요?
- [X] 주석 "상세히" 다셨나요?
- [X] 제출하기 전에 테스트코드 돌려 보셨나요?

closes #338 
